### PR TITLE
Switch low-latency TTS examples to PCM audio encoding

### DIFF
--- a/tts/js/example_tts_low_latency_http.js
+++ b/tts/js/example_tts_low_latency_http.js
@@ -100,33 +100,16 @@ async function httpStreamingTts(apiKey, text, voiceId, modelId) {
         }
 
         const reader = response.body.getReader();
-        const decoder = new TextDecoder();
-        let buffer = '';
 
         while (true) {
             const { done, value } = await reader.read();
             if (done) break;
 
-            buffer += decoder.decode(value, { stream: true });
-            const lines = buffer.split('\n');
-            buffer = lines.pop() || '';
-
-            for (const line of lines) {
-                if (line.trim()) {
-                    try {
-                        const chunkData = JSON.parse(line);
-                        const result = chunkData.result;
-                        if (result && result.audioContent) {
-                            const audioChunk = Buffer.from(result.audioContent, 'base64');
-                            if (ttfb === null) {
-                                ttfb = (Date.now() - startTime) / 1000;
-                            }
-                            totalAudioBytes += audioChunk.length;
-                        }
-                    } catch {
-                        continue;
-                    }
+            if (value && value.length > 0) {
+                if (ttfb === null) {
+                    ttfb = (Date.now() - startTime) / 1000;
                 }
+                totalAudioBytes += value.length;
             }
         }
 

--- a/tts/js/example_tts_low_latency_ws.js
+++ b/tts/js/example_tts_low_latency_ws.js
@@ -150,23 +150,23 @@ async function websocketTts(apiKey, text, voiceId, modelId) {
                     return;
                 }
 
+                // Audio chunk - base64-encoded PCM
+                if (result.audioChunk) {
+                    const b64Content = result.audioChunk.audioContent;
+                    if (b64Content) {
+                        const audioChunk = Buffer.from(b64Content, 'base64');
+                        if (ttfb === null) {
+                            ttfb = (Date.now() - startTime) / 1000;
+                        }
+                        totalAudioBytes += audioChunk.length;
+                    }
+                }
+
                 // Context closed - all audio received
                 if (result.contextClosed !== undefined) {
                     const totalTime = (Date.now() - startTime) / 1000;
                     finish({ ttfb, totalTime, audioBytes: totalAudioBytes });
                     return;
-                }
-
-                // Audio chunk
-                if (result.audioChunk) {
-                    const b64Content = result.audioChunk.audioContent;
-                    if (b64Content) {
-                        if (ttfb === null) {
-                            ttfb = (Date.now() - startTime) / 1000;
-                        }
-                        const audioBytes = Buffer.from(b64Content, 'base64');
-                        totalAudioBytes += audioBytes.length;
-                    }
                 }
 
             } catch {

--- a/tts/js/package-lock.json
+++ b/tts/js/package-lock.json
@@ -10,10 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "dotenv": "^16.0.0",
-        "ws": "^8.14.0"
+        "ws": "^8.20.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/dotenv": {
@@ -29,9 +29,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/tts/js/package.json
+++ b/tts/js/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "dependencies": {
     "dotenv": "^16.0.0",
-    "ws": "^8.14.0"
+    "ws": "^8.20.0"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/tts/python/example_tts_low_latency_http.py
+++ b/tts/python/example_tts_low_latency_http.py
@@ -9,7 +9,6 @@ Key technique: Use a persistent session to pre-establish the TCP+TLS connection
 with a small warmup request, then measure only the synthesis latency.
 """
 
-import base64
 import json
 import os
 import time
@@ -96,18 +95,11 @@ def http_streaming_tts(api_key, text, voice_id, model_id):
         with session.post(url, json=request_data, stream=True) as response:
             response.raise_for_status()
 
-            for line in response.iter_lines(decode_unicode=True):
-                if line.strip():
-                    try:
-                        chunk_data = json.loads(line)
-                        result = chunk_data.get("result")
-                        if result and "audioContent" in result:
-                            audio_chunk = base64.b64decode(result["audioContent"])
-                            if ttfb is None:
-                                ttfb = time.time() - start_time
-                            total_audio_bytes += len(audio_chunk)
-                    except json.JSONDecodeError:
-                        continue
+            for chunk in response.iter_content(chunk_size=None):
+                if chunk:
+                    if ttfb is None:
+                        ttfb = time.time() - start_time
+                    total_audio_bytes += len(chunk)
 
         total_time = time.time() - start_time
         return {"ttfb": ttfb, "total_time": total_time, "audio_bytes": total_audio_bytes}

--- a/tts/python/example_tts_low_latency_http.py
+++ b/tts/python/example_tts_low_latency_http.py
@@ -9,7 +9,6 @@ Key technique: Use a persistent session to pre-establish the TCP+TLS connection
 with a small warmup request, then measure only the synthesis latency.
 """
 
-import json
 import os
 import time
 

--- a/tts/python/example_tts_low_latency_ws.py
+++ b/tts/python/example_tts_low_latency_ws.py
@@ -134,8 +134,7 @@ async def websocket_tts(api_key, text, voice_id, model_id, auto_mode):
                     break
 
                 if "audioChunk" in result:
-                    audio_chunk = result["audioChunk"]
-                    b64_content = audio_chunk.get("audioContent")
+                    b64_content = result["audioChunk"].get("audioContent")
                     if b64_content:
                         now = time.time()
                         if ttfb is None:


### PR DESCRIPTION
## Summary

- Switch `audio_encoding` from OGG to PCM in all four low-latency TTS example scripts (Python + JS, HTTP + WebSocket)
- HTTP streaming: replace JSON line parsing with direct binary chunk iteration, since PCM responses are raw binary (no JSON wrapper)
- WebSocket: retain base64 JSON decoding path — the WS endpoint wraps PCM audio in JSON regardless of encoding
- Bump `ws` dependency to 8.20.0

## Test plan

- [x] Python HTTP: ran successfully — TTFB ~221 ms, 264 KB audio
- [x] Python WS: ran successfully — TTFB ~217 ms, 195 KB audio
- [x] JS HTTP: ran successfully — TTFB ~286 ms, 255 KB audio
- [x] JS WS: ran successfully — TTFB ~209 ms, 180 KB audio

🤖 Generated with [Claude Code](https://claude.com/claude-code)