### PR TITLE
Default examples to inworld-tts-2

### DIFF
--- a/integrations/telnyx/src/voice/inworld-realtime.ts
+++ b/integrations/telnyx/src/voice/inworld-realtime.ts
@@ -102,7 +102,7 @@ export class InworldRealtimeClient extends EventEmitter {
               },
               output: {
                 format: "g711_ulaw",
-                model: "inworld-tts-1.5-max",
+                model: "inworld-tts-2",
                 voice: "Sarah",
               },
             },

--- a/integrations/twilio-conversation-relay/.env.example
+++ b/integrations/twilio-conversation-relay/.env.example
@@ -16,8 +16,8 @@ INWORLD_MODEL=openai/gpt-4.1-mini
 # Inworld TTS voice name (default: Clive)
 TTS_VOICE=Clive
 
-# Inworld TTS model (default: inworld-tts-1.5-max)
-TTS_MODEL=inworld-tts-1.5-max
+# Inworld TTS model (default: inworld-tts-2)
+TTS_MODEL=inworld-tts-2
 
 # ConversationRelay transcription provider (default: Deepgram)
 TRANSCRIPTION_PROVIDER=Deepgram

--- a/integrations/twilio-conversation-relay/CLAUDE.md
+++ b/integrations/twilio-conversation-relay/CLAUDE.md
@@ -52,7 +52,7 @@ ngrok http 3000 --url=<your-ngrok-domain>
 - `SYSTEM_PROMPT` -- system instructions for the voice assistant
 - `INWORLD_MODEL` -- model or router name (default: `openai/gpt-4.1-mini`)
 - `TTS_VOICE` -- Inworld TTS voice name (default: `Clive`)
-- `TTS_MODEL` -- Inworld TTS model (default: `inworld-tts-1.5-max`)
+- `TTS_MODEL` -- Inworld TTS model (default: `inworld-tts-2`)
 - `TRANSCRIPTION_PROVIDER` -- STT provider (default: `Deepgram`)
 - `WELCOME_GREETING` -- greeting spoken when the call connects
 

--- a/integrations/twilio-conversation-relay/README.md
+++ b/integrations/twilio-conversation-relay/README.md
@@ -130,7 +130,7 @@ The server maintains full conversation history (system prompt plus all user and 
 | `SYSTEM_PROMPT` | No | Generic assistant prompt | System instructions sent to the LLM |
 | `INWORLD_MODEL` | No | `openai/gpt-4.1-mini` | LLM model or Inworld router name |
 | `TTS_VOICE` | No | `Clive` | Inworld TTS voice name |
-| `TTS_MODEL` | No | `inworld-tts-1.5-max` | Inworld TTS model (`inworld-tts-1.5-max` or `inworld-tts-1.5-mini`) |
+| `TTS_MODEL` | No | `inworld-tts-2` | Inworld TTS model (`inworld-tts-2`, `inworld-tts-1.5-max`, or `inworld-tts-1.5-mini`) |
 | `TRANSCRIPTION_PROVIDER` | No | `Deepgram` | Speech-to-text provider used by ConversationRelay |
 | `WELCOME_GREETING` | No | Generic greeting | Message spoken when the call connects |
 

--- a/integrations/twilio-conversation-relay/src/config.ts
+++ b/integrations/twilio-conversation-relay/src/config.ts
@@ -25,7 +25,7 @@ export const config = {
 
   // Inworld TTS settings
   ttsVoice: optional("TTS_VOICE", "Clive"),
-  ttsModel: optional("TTS_MODEL", "inworld-tts-1.5-max"),
+  ttsModel: optional("TTS_MODEL", "inworld-tts-2"),
 
   transcriptionProvider: optional("TRANSCRIPTION_PROVIDER", "Deepgram"),
 

--- a/integrations/twilio/src/voice/inworld-realtime.ts
+++ b/integrations/twilio/src/voice/inworld-realtime.ts
@@ -102,7 +102,7 @@ export class InworldRealtimeClient extends EventEmitter {
               },
               output: {
                 format: "g711_ulaw",
-                model: "inworld-tts-1.5-max",
+                model: "inworld-tts-2",
                 voice: "Sarah",
               },
             },

--- a/realtime/js/webrtc/basic/index.html
+++ b/realtime/js/webrtc/basic/index.html
@@ -154,7 +154,7 @@
             output_modalities: ['audio', 'text'],
             audio: {
               input: { turn_detection: { type: 'semantic_vad', eagerness: 'high', create_response: true, interrupt_response: true } },
-              output: { model: 'inworld-tts-1.5-mini', voice: 'Clive' }
+              output: { model: 'inworld-tts-2', voice: 'Clive' }
             }
           }
         });

--- a/realtime/js/webrtc/jwt/index.html
+++ b/realtime/js/webrtc/jwt/index.html
@@ -154,7 +154,7 @@
             output_modalities: ['audio', 'text'],
             audio: {
               input: { turn_detection: { type: 'semantic_vad', eagerness: 'high', create_response: true, interrupt_response: true } },
-              output: { model: 'inworld-tts-1.5-mini', voice: 'Clive' }
+              output: { model: 'inworld-tts-2', voice: 'Clive' }
             }
           }
         });

--- a/realtime/js/websockets/basic/index.html
+++ b/realtime/js/websockets/basic/index.html
@@ -262,7 +262,7 @@
                 output_modalities: ['audio', 'text'],
                 audio: {
                   input: { turn_detection: { type: 'semantic_vad', eagerness: 'high', create_response: true, interrupt_response: true } },
-                  output: { model: 'inworld-tts-1.5-mini', voice: 'Clive' }
+                  output: { model: 'inworld-tts-2', voice: 'Clive' }
                 }
               }
             });

--- a/realtime/js/websockets/jwt/index.html
+++ b/realtime/js/websockets/jwt/index.html
@@ -262,7 +262,7 @@
                 output_modalities: ['audio', 'text'],
                 audio: {
                   input: { turn_detection: { type: 'semantic_vad', eagerness: 'high', create_response: true, interrupt_response: true } },
-                  output: { model: 'inworld-tts-1.5-mini', voice: 'Clive' }
+                  output: { model: 'inworld-tts-2', voice: 'Clive' }
                 }
               }
             });

--- a/realtime/python/webrtc/basic/index.html
+++ b/realtime/python/webrtc/basic/index.html
@@ -154,7 +154,7 @@
             output_modalities: ['audio', 'text'],
             audio: {
               input: { turn_detection: { type: 'semantic_vad', eagerness: 'high', create_response: true, interrupt_response: true } },
-              output: { model: 'inworld-tts-1.5-mini', voice: 'Clive' }
+              output: { model: 'inworld-tts-2', voice: 'Clive' }
             }
           }
         });

--- a/realtime/python/webrtc/jwt/index.html
+++ b/realtime/python/webrtc/jwt/index.html
@@ -154,7 +154,7 @@
             output_modalities: ['audio', 'text'],
             audio: {
               input: { turn_detection: { type: 'semantic_vad', eagerness: 'high', create_response: true, interrupt_response: true } },
-              output: { model: 'inworld-tts-1.5-mini', voice: 'Clive' }
+              output: { model: 'inworld-tts-2', voice: 'Clive' }
             }
           }
         });

--- a/realtime/python/websockets/basic/index.html
+++ b/realtime/python/websockets/basic/index.html
@@ -262,7 +262,7 @@
                 output_modalities: ['audio', 'text'],
                 audio: {
                   input: { turn_detection: { type: 'semantic_vad', eagerness: 'high', create_response: true, interrupt_response: true } },
-                  output: { model: 'inworld-tts-1.5-mini', voice: 'Clive' }
+                  output: { model: 'inworld-tts-2', voice: 'Clive' }
                 }
               }
             });

--- a/realtime/python/websockets/jwt/index.html
+++ b/realtime/python/websockets/jwt/index.html
@@ -262,7 +262,7 @@
                 output_modalities: ['audio', 'text'],
                 audio: {
                   input: { turn_detection: { type: 'semantic_vad', eagerness: 'high', create_response: true, interrupt_response: true } },
-                  output: { model: 'inworld-tts-1.5-mini', voice: 'Clive' }
+                  output: { model: 'inworld-tts-2', voice: 'Clive' }
                 }
               }
             });

--- a/tts/README.md
+++ b/tts/README.md
@@ -8,6 +8,15 @@
 
 See each subdirectory's README for setup and usage.
 
+## Models
+
+All examples default to **`inworld-tts-2`**, the newest model. It supports 100+ languages and exposes two tts-2-only knobs:
+
+- [`deliveryMode`](https://docs.inworld.ai/api-reference/ttsAPI/texttospeech/synthesize-speech-stream#body-delivery-mode) — `STABLE`, `BALANCED` (default), or `CREATIVE` to trade off consistency vs. expressiveness.
+- [`language`](https://docs.inworld.ai/api-reference/ttsAPI/texttospeech/synthesize-speech-stream#body-language) — BCP-47 language tag (e.g., `en-US`, `fr-FR`, `ja-JP`).
+
+The previous-generation models `inworld-tts-1.5-max` and `inworld-tts-1.5-mini` are still supported — pass them via `model_id`/`modelId` (or `--model-id` on the CLI) if you need them. Temperature is only honored by the 1.5 family.
+
 ## TTS example options: when to use which
 
 For real-time use cases, minimizing latency is critical. Inworld offers three ways to synthesize speech; choose based on your latency and integration needs:

--- a/tts/js/README.md
+++ b/tts/js/README.md
@@ -163,8 +163,8 @@ All examples use the following default configuration:
 ```javascript
 const config = {
     text: "Hello, adventurer! What a beautiful day, isn't it?",
-    voiceId: "Dennis", // or "Ashley" for WebSocket example
-    modelId: "inworld-tts-1.5-max", // timestamp examples use "inworld-tts-1.5-max"
+    voiceId: "Sarah", // examples rotate across Sarah, Jason, Clive, Dennis, Hana
+    modelId: "inworld-tts-2", // newest default; inworld-tts-1.5-max / inworld-tts-1.5-mini still supported
     audioConfig: {
         audioEncoding: "LINEAR16",  // use "MP3" for streaming examples (example_tts_stream.js, example_tts_stream_timestamps.js)
         sampleRateHertz: 48000
@@ -174,6 +174,13 @@ const config = {
 ```
 
 You can modify these values in each example file to test different voices, models, or text content.
+
+### `inworld-tts-2`-only options
+
+- [`deliveryMode`](https://docs.inworld.ai/api-reference/ttsAPI/texttospeech/synthesize-speech-stream#body-delivery-mode) — `STABLE`, `BALANCED` (default), or `CREATIVE` to trade off consistency vs. expressiveness.
+- [`language`](https://docs.inworld.ai/api-reference/ttsAPI/texttospeech/synthesize-speech-stream#body-language) — BCP-47 tag (e.g., `en-US`, `fr-FR`, `ja-JP`) to drive the localized voice prompt.
+
+`temperature` is only honored by `inworld-tts-1.5` models and is ignored on `inworld-tts-2`.
 
 ## API Endpoints
 

--- a/tts/js/example_tts.js
+++ b/tts/js/example_tts.js
@@ -168,8 +168,8 @@ async function main() {
     
     // Configuration
     const text = "Hello, adventurer! What a beautiful day, isn't it?";
-    const voiceId = 'Dennis';
-    const modelId = 'inworld-tts-1.5-max'; // max model for non-streaming: higher quality
+    const voiceId = 'Sarah';
+    const modelId = 'inworld-tts-2'; // newest default; supports deliveryMode and language. Use 'inworld-tts-1.5-max' for the previous flagship.
     const sampleRateHz = 48000;
     const outputFile = 'synthesis_output.wav';
     

--- a/tts/js/example_tts_long_input.js
+++ b/tts/js/example_tts_long_input.js
@@ -529,8 +529,8 @@ async function main() {
     if (!apiKey) return 1;
     
     // Configuration - modify these for your use case
-    const voiceId = 'Edward';
-    const modelId = 'inworld-tts-1.5-max'; // max model for non-streaming: higher quality
+    const voiceId = 'Dennis';
+    const modelId = 'inworld-tts-2'; // newest default; supports deliveryMode and language. Use 'inworld-tts-1.5-max' for the previous flagship.
     const outputFile = 'synthesis_long_output.wav';
     const inputFile = path.join(__dirname, INPUT_FILE_PATH);
     

--- a/tts/js/example_tts_long_input_compressed.js
+++ b/tts/js/example_tts_long_input_compressed.js
@@ -456,8 +456,8 @@ async function main() {
     if (!apiKey) return 1;
     
     // Configuration - modify these for your use case
-    const voiceId = 'Edward';
-    const modelId = 'inworld-tts-1.5-max'; // max model for non-streaming: higher quality
+    const voiceId = 'Sarah';
+    const modelId = 'inworld-tts-2'; // newest default; supports deliveryMode and language. Use 'inworld-tts-1.5-max' for the previous flagship.
     const outputFile = 'synthesis_long_output.mp3';
     const inputFile = path.join(__dirname, INPUT_FILE_PATH);
     

--- a/tts/js/example_tts_low_latency_http.js
+++ b/tts/js/example_tts_low_latency_http.js
@@ -137,8 +137,8 @@ async function main() {
 
     // Configuration
     const text = "Life moves pretty fast. Look around once in a while, or you might miss it.";
-    const voiceId = 'Dennis';
-    const modelId = 'inworld-tts-1.5-mini'; // mini model for streaming: lower latency
+    const voiceId = 'Jason';
+    const modelId = 'inworld-tts-2'; // newest default; supports deliveryMode and language. Use 'inworld-tts-1.5-mini' for the fastest legacy model.
 
     console.log(`   Text: "${text}"`);
     console.log(`  Voice: ${voiceId}`);

--- a/tts/js/example_tts_low_latency_ws.js
+++ b/tts/js/example_tts_low_latency_ws.js
@@ -195,8 +195,8 @@ async function main() {
 
     // Configuration
     const text = "Life moves pretty fast. Look around once in a while, or you might miss it.";
-    const voiceId = 'Dennis';
-    const modelId = 'inworld-tts-1.5-mini'; // mini model for WebSocket: lower latency
+    const voiceId = 'Clive';
+    const modelId = 'inworld-tts-2'; // newest default; supports deliveryMode and language. Use 'inworld-tts-1.5-mini' for the fastest legacy model.
 
     console.log(`   Text: "${text}"`);
     console.log(`  Voice: ${voiceId}`);

--- a/tts/js/example_tts_stream.js
+++ b/tts/js/example_tts_stream.js
@@ -180,8 +180,8 @@ async function main() {
     
     // Configuration
     const text = "Hello, adventurer! What a beautiful day, isn't it?";
-    const voiceId = 'Dennis';
-    const modelId = 'inworld-tts-1.5-mini'; // mini model for streaming: lower latency
+    const voiceId = 'Jason';
+    const modelId = 'inworld-tts-2'; // newest default; supports deliveryMode and language. Use 'inworld-tts-1.5-mini' for the fastest legacy model.
     const outputFile = 'synthesis_stream_output.mp3';
     
     try {

--- a/tts/js/example_tts_stream_timestamps.js
+++ b/tts/js/example_tts_stream_timestamps.js
@@ -273,8 +273,8 @@ async function main() {
 
     // Configuration
     const text = "Hello, adventurer! What a beautiful day, isn't it?";
-    const voiceId = 'Dennis';
-    const modelId = 'inworld-tts-1.5-mini'; // mini model for streaming: lower latency
+    const voiceId = 'Hana';
+    const modelId = 'inworld-tts-2'; // newest default; supports deliveryMode and language. Use 'inworld-tts-1.5-mini' for the fastest legacy model.
     const outputFile = 'synthesis_stream_timestamps_output.mp3';
 
     try {

--- a/tts/js/example_tts_timestamps.js
+++ b/tts/js/example_tts_timestamps.js
@@ -246,8 +246,8 @@ async function main() {
 
     // Configuration
     const text = "Hello, adventurer! What a beautiful day, isn't it?";
-    const voiceId = 'Dennis';
-    const modelId = 'inworld-tts-1.5-max'; // max model for non-streaming: higher quality
+    const voiceId = 'Clive';
+    const modelId = 'inworld-tts-2'; // newest default; supports deliveryMode and language. Use 'inworld-tts-1.5-max' for the previous flagship.
     const sampleRateHz = 48000;
     const outputFile = 'synthesis_timestamps_output.wav';
 

--- a/tts/js/example_websocket.js
+++ b/tts/js/example_websocket.js
@@ -263,8 +263,8 @@ async function main() {
         {
             context_id: 'ctx-1',
             create: {
-                voice_id: 'Ashley',
-                model_id: 'inworld-tts-1.5-mini', // mini model for WebSocket: lower latency
+                voice_id: 'Hana',
+                model_id: 'inworld-tts-2', // newest default; supports deliveryMode and language. Use 'inworld-tts-1.5-mini' for the fastest legacy model.
                 audio_config: {
                     audio_encoding: 'OGG_OPUS',
                     sample_rate_hertz: 24000,

--- a/tts/js/tts_latency_comparison/frontend/index.html
+++ b/tts/js/tts_latency_comparison/frontend/index.html
@@ -153,7 +153,7 @@
                 <div class="model-header">
                     <div class="model-info">
                         <h3>Inworld</h3>
-                        <span class="model-badge standard">inworld-tts-1.5-mini</span>
+                        <span class="model-badge standard">inworld-tts-2</span>
                     </div>
                     <div class="model-controls">
                         <button id="inworld-play-btn" class="play-btn" disabled>

--- a/tts/js/tts_latency_comparison/src/services/inworldService.js
+++ b/tts/js/tts_latency_comparison/src/services/inworldService.js
@@ -101,9 +101,8 @@ class InworldService {
             const warmupBody = {
                 text: 'hi',
                 voiceId,
-                modelId: 'inworld-tts-1.5-mini',
-                audioConfig: { audioEncoding: 'MP3', sampleRateHertz: 44100 },
-                temperature: 1.0
+                modelId: 'inworld-tts-2',
+                audioConfig: { audioEncoding: 'MP3', sampleRateHertz: 44100 }
             };
             const warmupResponse = await fetch(url, { method: 'POST', headers, body: JSON.stringify(warmupBody) });
             if (warmupResponse.body) await warmupResponse.arrayBuffer();
@@ -113,16 +112,15 @@ class InworldService {
         const requestStartTime = Date.now();
         let timeToFirstByte = null;
 
-        // Prepare request body 
+        // Prepare request body
         const requestBody = {
             text: text,
             voiceId,
-            modelId: 'inworld-tts-1.5-mini',
+            modelId: 'inworld-tts-2',
             audioConfig: {
                 audioEncoding: 'MP3',
                 sampleRateHertz: 44100  // Standardized to 44.1kHz for better browser compatibility
-            },
-            temperature: 1.0
+            }
         };
 
         const response = await fetch(url, {

--- a/tts/python/README.md
+++ b/tts/python/README.md
@@ -168,19 +168,19 @@ python example_tts_low_latency_ws.py
 - Support for all synthesis methods (basic, streaming, WebSocket)
 - Batch testing with JSON sample files
 - Performance benchmarking
-- Advanced configuration options (temperature, timestamps, normalization)
+- Optional flags for timestamps and text normalization
 - Statistics and timing analysis
 
 **Usage:**
 ```bash
-# Basic synthesis
+# Basic synthesis (defaults to inworld-tts-2)
 python tts_cli.py --output-file output.wav --text "Hello world"
 
 # Streaming synthesis with timestamp alignment
 python tts_cli.py --output-file output.wav --text "Hello world" --stream --timestamp word
 
-# Custom temperature and text normalization
-python tts_cli.py --output-file output.wav --temperature 0.8 --text-normalization off
+# Text normalization off
+python tts_cli.py --output-file output.wav --text-normalization off
 
 # Batch testing with JSON samples
 python tts_cli.py --json-example ../tests-data/tts/tts_marketing_samples.json
@@ -188,7 +188,7 @@ python tts_cli.py --json-example ../tests-data/tts/tts_marketing_samples.json
 # Batch testing with streaming and character-level timestamps
 python tts_cli.py --json-example ../tests-data/tts/tts_marketing_samples.json --stream --timestamp character
 
-# Custom voice and model with all options
+# Pin to a specific tts-1.5 model (temperature only supported on tts-1.5)
 python tts_cli.py --output-file output.wav --voice-id Dennis --model-id inworld-tts-1.5-max --temperature 1.2 --timestamp word --text-normalization on
 ```
 
@@ -235,11 +235,13 @@ python example_voice_design_publish.py
 
 All examples support the following configuration through code modification:
 
-- **Voice ID:** Choose from available voices (default: "Dennis")
-- **Model ID:** TTS model to use (default: "inworld-tts-1.5-max")
+- **Voice ID:** Choose from available voices. Examples rotate across `Sarah`, `Jason`, `Clive`, `Dennis`, and `Hana`.
+- **Model ID:** TTS model to use (default: `inworld-tts-2`; `inworld-tts-1.5-max` and `inworld-tts-1.5-mini` are still supported)
 - **Audio Format:** LINEAR16, 48kHz for non-streaming; streaming examples (`example_tts_stream.py`, `example_tts_stream_timestamps.py`) use MP3
 - **Output File:** Customize output filename and location
-- **Temperature:** Control voice variation (0.0-1.0)
+- **Delivery Mode** *(`inworld-tts-2` only)*: `STABLE`, `BALANCED` (default), or `CREATIVE` — see [docs](https://docs.inworld.ai/api-reference/ttsAPI/texttospeech/synthesize-speech-stream#body-delivery-mode).
+- **Language** *(`inworld-tts-2` only)*: BCP-47 tag such as `en-US`, `fr-FR`, `ja-JP` — see [docs](https://docs.inworld.ai/api-reference/ttsAPI/texttospeech/synthesize-speech-stream#body-language).
+- **Temperature** *(`inworld-tts-1.5` only)*: Control voice variation (0.0-2.0). Ignored on `inworld-tts-2`.
 - **Timestamps:** Get word-level timing information
 - **Text Normalization:** Control how text is processed
 - **Batch Processing:** Process multiple texts from JSON files

--- a/tts/python/README.md
+++ b/tts/python/README.md
@@ -169,6 +169,7 @@ python example_tts_low_latency_ws.py
 - Batch testing with JSON sample files
 - Performance benchmarking
 - Optional flags for timestamps and text normalization
+- Optional `--temperature` control for `inworld-tts-1.5-*` models
 - Statistics and timing analysis
 
 **Usage:**

--- a/tts/python/example_tts.py
+++ b/tts/python/example_tts.py
@@ -125,8 +125,8 @@ def main():
     
     # Configuration
     text = "Hello, adventurer! What a beautiful day, isn't it?"
-    voice_id = "Dennis"
-    model_id = "inworld-tts-1.5-max"  # max model for non-streaming: higher quality
+    voice_id = "Sarah"
+    model_id = "inworld-tts-2"  # newest default; supports delivery_mode and language. Use inworld-tts-1.5-max for the previous flagship.
     sample_rate_hz = 48000
     output_file = "synthesis_output.wav"
 

--- a/tts/python/example_tts_long_input.py
+++ b/tts/python/example_tts_long_input.py
@@ -468,8 +468,8 @@ def main():
         return 1
     
     # Configuration - modify these for your use case
-    voice_id = "Edward"
-    model_id = "inworld-tts-1.5-max"  # max model for non-streaming: higher quality
+    voice_id = "Dennis"
+    model_id = "inworld-tts-2"  # newest default; supports delivery_mode and language. Use inworld-tts-1.5-max for the previous flagship.
     output_file = "synthesis_long_output.wav"
     
     script_dir = Path(__file__).parent

--- a/tts/python/example_tts_long_input_compressed.py
+++ b/tts/python/example_tts_long_input_compressed.py
@@ -408,8 +408,8 @@ def main():
         return 1
     
     # Configuration - modify these for your use case
-    voice_id = "Edward"
-    model_id = "inworld-tts-1.5-max"  # max model for non-streaming: higher quality
+    voice_id = "Sarah"
+    model_id = "inworld-tts-2"  # newest default; supports delivery_mode and language. Use inworld-tts-1.5-max for the previous flagship.
     output_file = "synthesis_long_output.mp3"
     
     script_dir = Path(__file__).parent

--- a/tts/python/example_tts_low_latency_http.py
+++ b/tts/python/example_tts_low_latency_http.py
@@ -128,8 +128,8 @@ def main():
 
     # Configuration
     text = "Life moves pretty fast. Look around once in a while, or you might miss it."
-    voice_id = "Dennis"
-    model_id = "inworld-tts-1.5-mini"  # mini model for streaming: lower latency
+    voice_id = "Jason"
+    model_id = "inworld-tts-2"  # newest default; supports delivery_mode and language. Use inworld-tts-1.5-mini for the fastest legacy model.
 
     print(f"   Text: \"{text}\"")
     print(f"  Voice: {voice_id}")

--- a/tts/python/example_tts_low_latency_ws.py
+++ b/tts/python/example_tts_low_latency_ws.py
@@ -172,8 +172,8 @@ async def main():
 
     # Configuration
     text = "Life moves pretty fast. Look around once in a while, or you might miss it."
-    voice_id = "Dennis"
-    model_id = "inworld-tts-1.5-mini"
+    voice_id = "Clive"
+    model_id = "inworld-tts-2"  # newest default; supports delivery_mode and language. Use inworld-tts-1.5-mini for the fastest legacy model.
     auto_mode = False
 
     print(f"   Text: \"{text}\"")

--- a/tts/python/example_tts_stream.py
+++ b/tts/python/example_tts_stream.py
@@ -152,8 +152,8 @@ def main():
     
     # Configuration
     text = "Hello, adventurer! What a beautiful day, isn't it?"
-    voice_id = "Dennis"
-    model_id = "inworld-tts-1.5-mini"  # mini model for streaming: lower latency
+    voice_id = "Jason"
+    model_id = "inworld-tts-2"  # newest default; supports delivery_mode and language. Use inworld-tts-1.5-mini for the fastest legacy model.
     output_file = "synthesis_stream_output.mp3"
     
     try:

--- a/tts/python/example_tts_stream_timestamps.py
+++ b/tts/python/example_tts_stream_timestamps.py
@@ -234,8 +234,8 @@ def main():
 
     # Configuration
     text = "Hello, adventurer! What a beautiful day, isn't it?"
-    voice_id = "Dennis"
-    model_id = "inworld-tts-1.5-mini"  # mini model for streaming: lower latency
+    voice_id = "Hana"
+    model_id = "inworld-tts-2"  # newest default; supports delivery_mode and language. Use inworld-tts-1.5-mini for the fastest legacy model.
     output_file = "synthesis_stream_timestamps_output.mp3"
 
     try:

--- a/tts/python/example_tts_timestamps.py
+++ b/tts/python/example_tts_timestamps.py
@@ -191,8 +191,8 @@ def main():
 
     # Configuration (sample rate must match between API request and WAV file)
     text = "Hello, adventurer! What a beautiful day, isn't it?"
-    voice_id = "Dennis"
-    model_id = "inworld-tts-1.5-max"  # max model for non-streaming: higher quality
+    voice_id = "Clive"
+    model_id = "inworld-tts-2"  # newest default; supports delivery_mode and language. Use inworld-tts-1.5-max for the previous flagship.
     sample_rate_hz = 48000
     output_file = "synthesis_timestamps_output.wav"
 

--- a/tts/python/example_websocket.py
+++ b/tts/python/example_websocket.py
@@ -235,17 +235,17 @@ Examples:
   # WebSocket synthesis with word-level timestamps
   python example_websocket.py --timestamp word
   
-  # WebSocket synthesis with custom model and character timestamps
+  # WebSocket synthesis with the previous-generation streaming model
   python example_websocket.py --model-id inworld-tts-1.5-mini --timestamp character
         """
     )
-    
-    parser.add_argument("--model-id", default="inworld-tts-1.5-mini", 
-                       help="Model ID to use (default: inworld-tts-1.5-mini)")
+
+    parser.add_argument("--model-id", default="inworld-tts-2",
+                       help="Model ID to use (default: inworld-tts-2; supports delivery_mode and language)")
     parser.add_argument("--timestamp", choices=["word", "character"], default=None,
                        help="Enable timestamp alignment: 'word' for word-level, 'character' for character-level")
-    parser.add_argument("--voice-id", default="Ashley",
-                       help="Voice ID to use (default: Ashley)")
+    parser.add_argument("--voice-id", default="Hana",
+                       help="Voice ID to use (default: Hana)")
     parser.add_argument("--text", default="Hello, adventurer! What a beautiful day, isn't it?...",
                        help="Text to synthesize")
     parser.add_argument("--auto-mode", action="store_true",

--- a/tts/python/tts_cli.py
+++ b/tts/python/tts_cli.py
@@ -260,28 +260,29 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  # Basic synthesis
+  # Basic synthesis (uses inworld-tts-2)
   python tts_cli.py --output-file output.wav --text "Hello world"
-  
+
   # Streaming synthesis with timestamp alignment
   python tts_cli.py --output-file output.wav --text "Hello world" --stream --timestamp word
-  
-  # Custom temperature and text normalization
-  python tts_cli.py --output-file output.wav --temperature 0.8 --text-normalization off
-  
+
+  # Text normalization off
+  python tts_cli.py --output-file output.wav --text-normalization off
+
   # Batch testing with JSON samples
   python tts_cli.py --json-example ../tests-data/tts/tts_marketing_samples.json
 
   # Batch testing with streaming and character-level timestamps
   python tts_cli.py --json-example ../tests-data/tts/tts_marketing_samples.json --stream --timestamp character
-  
-  # Custom voice and model with all options
+
+  # Pin to a specific tts-1.5 model (temperature only supported on tts-1.5)
   python tts_cli.py --output-file output.wav --voice-id Dennis --model-id inworld-tts-1.5-mini --temperature 1.2 --timestamp word --text-normalization on
         """
     )
-    
+
     # Required parameters
-    parser.add_argument("--model-id", default="inworld-tts-1.5-mini", help="Model ID to use (default: inworld-tts-1.5-mini)")
+    parser.add_argument("--model-id", default="inworld-tts-2",
+                       help="Model ID to use (default: inworld-tts-2; pass inworld-tts-1.5-max or inworld-tts-1.5-mini for the previous generation)")
     parser.add_argument("--voice-id", default="Dennis", help="Voice ID to use (default: Dennis)")
     
     # Text input options
@@ -292,8 +293,8 @@ Examples:
     # Audio options
     parser.add_argument("--sample-rate", type=int, default=48000, help="Sample rate (default: 48000)")
     parser.add_argument("--stream", action="store_true", help="Use streaming synthesis")
-    parser.add_argument("--temperature", type=float, default=None, 
-                       help="Sampling temperature (0.0-2.0). Higher values = more random/expressive")
+    parser.add_argument("--temperature", type=float, default=None,
+                       help="Sampling temperature (0.0-2.0). Only supported on inworld-tts-1.5 models; ignored on inworld-tts-2")
     parser.add_argument("--timestamp", choices=["word", "character"], default=None,
                        help="Enable timestamp alignment: 'word' for word-level, 'character' for character-level")
     parser.add_argument("--text-normalization", choices=["on", "off"], default=None,


### PR DESCRIPTION
## Summary
- Switches the default TTS model across every example (TTS examples, integrations, realtime) from `inworld-tts-1.5-{max,mini}` to `inworld-tts-2` — the newest model with 100+ language support and the [`deliveryMode`](https://docs.inworld.ai/api-reference/ttsAPI/texttospeech/synthesize-speech-stream#body-delivery-mode) / [`language`](https://docs.inworld.ai/api-reference/ttsAPI/texttospeech/synthesize-speech-stream#body-language) knobs.
- `inworld-tts-1.5-max` and `inworld-tts-1.5-mini` remain supported; each example notes how to opt back in via the model id, and `tts_cli.py`'s `--temperature` is documented as tts-1.5-only (tts-2 ignores it).
- Rotates example voices across **Sarah, Jason, Clive, Dennis, Hana** instead of always using Dennis / Edward / Ashley.
- READMEs (`tts/README.md`, `tts/python/README.md`, `tts/js/README.md`) gained a short tts-2 section linking to the new docs.
- Latency comparison: the default "Inworld" lane runs `inworld-tts-2`; the dedicated `inworld-tts-1.5-max` lane is kept as an apples-to-apples benchmark.

## Test plan
- [ ] `python tts/python/example_tts.py` produces audio with `inworld-tts-2`
- [ ] `node tts/js/example_tts.js` produces audio with `inworld-tts-2`
- [ ] `python tts/python/example_websocket.py` (and JS equivalent) connect and stream audio
- [ ] `python tts/python/tts_cli.py --output-file /tmp/out.wav` works and `--temperature` is silently dropped on tts-2
- [ ] Spot-check `integrations/twilio-conversation-relay` boots with `TTS_MODEL=inworld-tts-2` (and falls back via `TTS_MODEL=inworld-tts-1.5-max`)
- [ ] Latency comparison frontend renders the new badge and Inworld lane responds