### PR TITLE
feat(realtime/ios): add native iOS WebRTC voice-agent example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ inworld-api-examples/
 │   └── js/
 └── realtime/
     ├── python/
-    └── js/
+    ├── js/
+    └── ios/
 ```
 
 ## Getting Started
@@ -60,3 +61,4 @@ Covers WebSocket and WebRTC-based real-time voice agents with both basic and JWT
 
 - **[Python](./realtime/python/)** — Real-time voice agent examples in Python
 - **[JavaScript](./realtime/js/)** — Real-time voice agent examples in JavaScript
+- **[iOS](./realtime/ios/)** — Native SwiftUI WebRTC voice-agent app

--- a/realtime/ios/webrtc/.gitignore
+++ b/realtime/ios/webrtc/.gitignore
@@ -1,0 +1,6 @@
+*.xcodeproj
+Sources/App/Secrets.swift
+DerivedData/
+.DS_Store
+xcuserdata/
+.build/

--- a/realtime/ios/webrtc/README.md
+++ b/realtime/ios/webrtc/README.md
@@ -1,0 +1,66 @@
+# Inworld Realtime — iOS (WebRTC)
+
+A native iOS voice-agent app for the Inworld Realtime API over WebRTC: it streams
+mic audio to the API, plays the agent's audio reply, and shows a live chat
+transcript of both sides. It mirrors the [JS WebRTC example](../../js/webrtc) and
+supports both of its auth variants (`basic` and `jwt`) via an in-app picker.
+
+- SwiftUI, iOS 17+
+- WebRTC via [stasel/WebRTC](https://github.com/stasel/WebRTC) (SPM binary xcframework)
+- Project generated with [XcodeGen](https://github.com/yonaskolb/XcodeGen)
+
+## Features
+
+- Full-duplex voice over a single WebRTC peer connection (Opus mic + agent audio track)
+- Streaming chat transcript — agent text and partial user transcripts update live
+- Barge-in: speaking interrupts the agent (mutes its track + `response.cancel`)
+- Back-channel audio ("uh-huh") played out-of-band so it stays audible while you talk
+- Settings for model, voice, instructions, turn detection, back-channel, and
+  responsiveness, plus live model/voice pickers fetched from the Inworld APIs
+
+## Setup
+
+```sh
+brew install xcodegen
+cp Sources/App/Secrets.swift.example Sources/App/Secrets.swift
+xcodegen generate
+open InworldVoiceAgent.xcodeproj
+```
+
+`Secrets.swift` is gitignored. Either paste your base64 `INWORLD_API_KEY` into it
+(used as the default), or leave it empty and enter the key at runtime in the app's
+Settings (gear icon) — it's stored in the Keychain. Then tap **Connect** and talk.
+Never commit a real key.
+
+### Auth modes
+
+- **API Key (Basic)** — the key is sent as `Authorization: Basic <key>` directly to
+  `api.inworld.ai`. Simplest; fine for development. Mirrors `js/webrtc/basic`.
+- **Backend JWT** — the app fetches `{ jwt, ice_servers, url }` from `<backend>/api/config`,
+  i.e. the [`js/webrtc/jwt`](../../js/webrtc/jwt) Node server. No Inworld secrets ship
+  in the app.
+
+## How it works
+
+1. `GET /v1/realtime/ice-servers` → ICE config.
+2. `RTCPeerConnection` + data channel `oai-events` + mic audio track.
+3. Offer SDP → `POST /v1/realtime/calls` (`Content-Type: application/sdp`) → answer SDP.
+4. On data-channel open: `session.update` (model, instructions, semantic VAD,
+   `inworld-tts-2` voice), greeting `conversation.item.create`, `response.create`.
+5. Agent audio arrives as a remote WebRTC track (auto-plays); transcripts stream over
+   the data channel. On `input_audio_buffer.speech_started` the app mutes the agent
+   track, sends `response.cancel`, and drops the in-flight bubble (barge-in).
+
+## Build & test from CLI
+
+```sh
+xcodegen generate
+xcodebuild build -project InworldVoiceAgent.xcodeproj -scheme InworldVoiceAgent \
+  -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO
+xcodebuild test -project InworldVoiceAgent.xcodeproj -scheme InworldVoiceAgent \
+  -destination 'platform=iOS Simulator,name=iPhone 16'
+```
+
+Note: the simulator passes through the Mac mic/speakers, so an end-to-end smoke test
+works there, but echo cancellation, speaker routing, Bluetooth, and background audio
+need a physical device.

--- a/realtime/ios/webrtc/Sources/App/AppModel.swift
+++ b/realtime/ios/webrtc/Sources/App/AppModel.swift
@@ -1,0 +1,17 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class AppModel {
+    let settings: SettingsStore
+    let conversation: ConversationViewModel
+    let catalog: CatalogStore
+
+    init() {
+        let settings = SettingsStore()
+        self.settings = settings
+        conversation = ConversationViewModel(settings: settings)
+        catalog = CatalogStore(settings: settings)
+    }
+}

--- a/realtime/ios/webrtc/Sources/App/InworldVoiceAgentApp.swift
+++ b/realtime/ios/webrtc/Sources/App/InworldVoiceAgentApp.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@main
+struct InworldVoiceAgentApp: App {
+    @State private var model = AppModel()
+
+    var body: some Scene {
+        WindowGroup {
+            ConversationView()
+                .environment(model)
+        }
+    }
+}

--- a/realtime/ios/webrtc/Sources/App/Secrets.swift.example
+++ b/realtime/ios/webrtc/Sources/App/Secrets.swift.example
@@ -1,0 +1,5 @@
+// Dev-only convenience. Paste your base64 INWORLD_API_KEY below to skip the
+// Settings screen. This file is gitignored — never commit a real key.
+enum Secrets {
+    static let inworldAPIKey = ""
+}

--- a/realtime/ios/webrtc/Sources/Auth/AuthProvider.swift
+++ b/realtime/ios/webrtc/Sources/Auth/AuthProvider.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+struct IceServer: Decodable, Equatable {
+    var urls: [String]
+    var username: String?
+    var credential: String?
+
+    enum CodingKeys: String, CodingKey {
+        case urls, username, credential
+    }
+
+    init(urls: [String], username: String? = nil, credential: String? = nil) {
+        self.urls = urls
+        self.username = username
+        self.credential = credential
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        // "urls" may be a single string or an array of strings
+        if let single = try? container.decode(String.self, forKey: .urls) {
+            urls = [single]
+        } else {
+            urls = try container.decode([String].self, forKey: .urls)
+        }
+        username = try container.decodeIfPresent(String.self, forKey: .username)
+        credential = try container.decodeIfPresent(String.self, forKey: .credential)
+    }
+}
+
+struct RealtimeCredentials {
+    var authorizationHeader: String
+    var apiBaseURL: URL
+    var callsURL: URL?
+    var preFetchedIceServers: [IceServer]?
+}
+
+enum AuthError: LocalizedError {
+    case missingAPIKey
+    case invalidBackendURL
+    case backendRequestFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingAPIKey: "Inworld API key is not set. Add it in Settings."
+        case .invalidBackendURL: "Backend URL is invalid."
+        case .backendRequestFailed(let detail): "Backend config request failed: \(detail)"
+        }
+    }
+}
+
+protocol AuthProvider {
+    func credentials() async throws -> RealtimeCredentials
+}

--- a/realtime/ios/webrtc/Sources/Auth/BackendJWTAuthProvider.swift
+++ b/realtime/ios/webrtc/Sources/Auth/BackendJWTAuthProvider.swift
@@ -32,10 +32,17 @@ struct BackendJWTAuthProvider: AuthProvider {
         } catch {
             throw AuthError.backendRequestFailed("invalid config payload")
         }
+        var callsURL: URL?
+        if let urlString = config.url, !urlString.isEmpty {
+            guard let parsed = URL(string: urlString) else {
+                throw AuthError.backendRequestFailed("backend returned an invalid calls url: \(urlString)")
+            }
+            callsURL = parsed
+        }
         return RealtimeCredentials(
             authorizationHeader: "Bearer \(config.jwt)",
             apiBaseURL: URL(string: "https://api.inworld.ai")!,
-            callsURL: config.url.flatMap(URL.init(string:)),
+            callsURL: callsURL,
             preFetchedIceServers: config.iceServers
         )
     }

--- a/realtime/ios/webrtc/Sources/Auth/BackendJWTAuthProvider.swift
+++ b/realtime/ios/webrtc/Sources/Auth/BackendJWTAuthProvider.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Fetches a short-lived JWT from a trusted backend (the JS example's `webrtc/jwt`
+/// Node server) so no Inworld key/secret ships in the app.
+struct BackendJWTAuthProvider: AuthProvider {
+    var backendURL: String
+    var session: URLSession = .shared
+
+    private struct ConfigResponse: Decodable {
+        var jwt: String
+        var iceServers: [IceServer]?
+        var url: String?
+
+        enum CodingKeys: String, CodingKey {
+            case jwt
+            case iceServers = "ice_servers"
+            case url
+        }
+    }
+
+    func credentials() async throws -> RealtimeCredentials {
+        guard let base = URL(string: backendURL) else { throw AuthError.invalidBackendURL }
+        let configURL = base.appending(path: "api/config")
+        let (data, response) = try await session.data(from: configURL)
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+            throw AuthError.backendRequestFailed("HTTP \(status)")
+        }
+        let config: ConfigResponse
+        do {
+            config = try JSONDecoder().decode(ConfigResponse.self, from: data)
+        } catch {
+            throw AuthError.backendRequestFailed("invalid config payload")
+        }
+        return RealtimeCredentials(
+            authorizationHeader: "Bearer \(config.jwt)",
+            apiBaseURL: URL(string: "https://api.inworld.ai")!,
+            callsURL: config.url.flatMap(URL.init(string:)),
+            preFetchedIceServers: config.iceServers
+        )
+    }
+}

--- a/realtime/ios/webrtc/Sources/Auth/BasicAuthProvider.swift
+++ b/realtime/ios/webrtc/Sources/Auth/BasicAuthProvider.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct BasicAuthProvider: AuthProvider {
+    var apiKey: String
+    var apiBaseURL = URL(string: "https://api.inworld.ai")!
+
+    func credentials() async throws -> RealtimeCredentials {
+        let key = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !key.isEmpty else { throw AuthError.missingAPIKey }
+        return RealtimeCredentials(
+            authorizationHeader: "Basic \(key)",
+            apiBaseURL: apiBaseURL,
+            callsURL: nil,
+            preFetchedIceServers: nil
+        )
+    }
+}

--- a/realtime/ios/webrtc/Sources/Info.plist
+++ b/realtime/ios/webrtc/Sources/Info.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Microphone is used to talk to the voice agent.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/realtime/ios/webrtc/Sources/Realtime/AudioSessionController.swift
+++ b/realtime/ios/webrtc/Sources/Realtime/AudioSessionController.swift
@@ -1,0 +1,29 @@
+import AVFoundation
+import WebRTC
+
+enum AudioSessionController {
+    /// Must run before the peer connection factory is created: WebRTC re-applies
+    /// this template whenever its audio unit starts, so it is the reliable lever
+    /// for speaker routing (`.voiceChat` alone routes to the earpiece).
+    static func configureForVoiceChat() {
+        let config = RTCAudioSessionConfiguration.webRTC()
+        config.category = AVAudioSession.Category.playAndRecord.rawValue
+        config.mode = AVAudioSession.Mode.voiceChat.rawValue
+        config.categoryOptions = [.defaultToSpeaker, .allowBluetooth, .allowBluetoothA2DP]
+        RTCAudioSessionConfiguration.setWebRTC(config)
+    }
+
+    static func overrideToSpeaker() {
+        let session = RTCAudioSession.sharedInstance()
+        session.lockForConfiguration()
+        try? session.overrideOutputAudioPort(.speaker)
+        session.unlockForConfiguration()
+    }
+
+    static func deactivate() {
+        let session = RTCAudioSession.sharedInstance()
+        session.lockForConfiguration()
+        try? session.setActive(false)
+        session.unlockForConfiguration()
+    }
+}

--- a/realtime/ios/webrtc/Sources/Realtime/BackchannelAudioPlayer.swift
+++ b/realtime/ios/webrtc/Sources/Realtime/BackchannelAudioPlayer.swift
@@ -1,0 +1,81 @@
+import AVFoundation
+import OSLog
+
+/// Plays back-channel interjections, which arrive as base64 PCM16 chunks on the data
+/// channel (separate from the WebRTC remote track). Kept independent so it stays audible
+/// while the user speaks — the docs require back-channels to be exempt from ducking.
+///
+/// The engine is built lazily on the first chunk, NOT at init: WebRTC only activates and
+/// configures the shared audio session when a call connects, and an AVAudioEngine created
+/// before that latches onto an invalid output format and fails to start.
+final class BackchannelAudioPlayer {
+    private static let log = Logger(subsystem: "ai.inworld.InworldVoiceAgent", category: "backchannel")
+
+    private var engine: AVAudioEngine?
+    private var player: AVAudioPlayerNode?
+
+    /// Back-channel audio is the realtime output format's default: audio/pcm @ 24 kHz mono.
+    private let format = AVAudioFormat(commonFormat: .pcmFormatFloat32,
+                                       sampleRate: 24000,
+                                       channels: 1,
+                                       interleaved: false)!
+
+    func enqueue(base64PCM16: String) {
+        guard let data = Data(base64Encoded: base64PCM16), !data.isEmpty else {
+            Self.log.error("back-channel chunk failed base64 decode")
+            return
+        }
+        guard let player = ensureRunning(),
+              let buffer = Self.makeBuffer(from: data, format: format) else { return }
+        player.scheduleBuffer(buffer, completionHandler: nil)
+        if !player.isPlaying { player.play() }
+    }
+
+    /// Tears the graph down so the next call rebuilds against a fresh, active session.
+    func stop() {
+        player?.stop()
+        engine?.stop()
+        player = nil
+        engine = nil
+    }
+
+    private func ensureRunning() -> AVAudioPlayerNode? {
+        if let engine, engine.isRunning, let player {
+            return player
+        }
+        let engine = self.engine ?? AVAudioEngine()
+        let player = self.player ?? AVAudioPlayerNode()
+        if self.engine == nil {
+            engine.attach(player)
+            engine.connect(player, to: engine.mainMixerNode, format: format)
+            self.engine = engine
+            self.player = player
+        }
+        do {
+            engine.prepare()
+            try engine.start()
+            player.play()
+            return player
+        } catch {
+            Self.log.error("AVAudioEngine failed to start: \(error.localizedDescription, privacy: .public)")
+            self.engine = nil
+            self.player = nil
+            return nil
+        }
+    }
+
+    static func makeBuffer(from pcm16: Data, format: AVAudioFormat) -> AVAudioPCMBuffer? {
+        let sampleCount = pcm16.count / 2
+        guard sampleCount > 0,
+              let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(sampleCount)),
+              let channel = buffer.floatChannelData else { return nil }
+        buffer.frameLength = AVAudioFrameCount(sampleCount)
+        pcm16.withUnsafeBytes { raw in
+            let samples = raw.bindMemory(to: Int16.self)
+            for i in 0..<sampleCount {
+                channel[0][i] = Float(Int16(littleEndian: samples[i])) / 32768.0
+            }
+        }
+        return buffer
+    }
+}

--- a/realtime/ios/webrtc/Sources/Realtime/CatalogAPI.swift
+++ b/realtime/ios/webrtc/Sources/Realtime/CatalogAPI.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+struct LLMModelInfo: Decodable, Identifiable, Equatable {
+    var model: String
+    var provider: String?
+    var modelCreator: String?
+    var isSupported: Bool?
+
+    var id: String { model }
+
+    /// Realtime API expects a `provider/model` identifier (e.g. "openai/gpt-4o-mini",
+    /// "inworld/models/GLM-5.1"), while list-models returns the model and provider
+    /// separately. The model string may itself contain slashes, so prefix the provider
+    /// unconditionally unless it is already present.
+    var realtimeIdentifier: String {
+        guard let provider, !provider.isEmpty else { return model }
+        if model.hasPrefix("\(provider)/") { return model }
+        return "\(provider)/\(model)"
+    }
+}
+
+struct VoiceInfo: Decodable, Identifiable, Equatable {
+    var voiceId: String
+    var displayName: String?
+    var langCode: String?
+    var description: String?
+    var gender: String?
+    var source: String?
+
+    var id: String { voiceId }
+}
+
+struct CatalogAPI {
+    var credentials: RealtimeCredentials
+    var session: URLSession = .shared
+
+    private struct ModelsResponse: Decodable { var models: [LLMModelInfo]? }
+    private struct VoicesResponse: Decodable {
+        var voices: [VoiceInfo]?
+        var nextPageToken: String?
+    }
+
+    func fetchModels() async throws -> [LLMModelInfo] {
+        let url = credentials.apiBaseURL.appending(path: "llm/v1alpha/models")
+        let data = try await get(url)
+        let models = try JSONDecoder().decode(ModelsResponse.self, from: data).models ?? []
+        return models.sorted { $0.realtimeIdentifier < $1.realtimeIdentifier }
+    }
+
+    func fetchVoices() async throws -> [VoiceInfo] {
+        var voices: [VoiceInfo] = []
+        var pageToken: String?
+        repeat {
+            var components = URLComponents(
+                url: credentials.apiBaseURL.appending(path: "voices/v1/voices"),
+                resolvingAgainstBaseURL: false
+            )!
+            var items = [URLQueryItem(name: "pageSize", value: "2000")]
+            if let pageToken { items.append(URLQueryItem(name: "pageToken", value: pageToken)) }
+            components.queryItems = items
+
+            let data = try await get(components.url!)
+            let page = try JSONDecoder().decode(VoicesResponse.self, from: data)
+            voices.append(contentsOf: page.voices ?? [])
+            pageToken = (page.nextPageToken?.isEmpty == false) ? page.nextPageToken : nil
+        } while pageToken != nil
+
+        return voices.sorted { ($0.displayName ?? $0.voiceId) < ($1.displayName ?? $1.voiceId) }
+    }
+
+    private func get(_ url: URL) async throws -> Data {
+        var request = URLRequest(url: url)
+        request.setValue(credentials.authorizationHeader, forHTTPHeaderField: "Authorization")
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else { throw SignalingError.malformedResponse }
+        guard (200..<300).contains(http.statusCode) else {
+            throw SignalingError.httpError(http.statusCode, String(data: data, encoding: .utf8) ?? "")
+        }
+        return data
+    }
+}

--- a/realtime/ios/webrtc/Sources/Realtime/Events/ClientEvents.swift
+++ b/realtime/ios/webrtc/Sources/Realtime/Events/ClientEvents.swift
@@ -1,0 +1,221 @@
+import Foundation
+
+enum ClientEventEncoder {
+    /// The realtime session schema is snake_case everywhere EXCEPT the single key
+    /// `providerData`, which the Go server unmarshals as camelCase
+    /// (`json:"providerData"`). A blanket .convertToSnakeCase would emit
+    /// `provider_data`, which the server silently ignores — so back-channel and
+    /// responsiveness never turn on. Convert everything except that one key.
+    private static let camelCaseKeys: Set<String> = ["providerData"]
+
+    static func encode(_ event: some Encodable) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .custom { path in
+            let key = path.last!
+            if camelCaseKeys.contains(key.stringValue) { return key }
+            return AnyCodingKey(stringValue: snakeCased(key.stringValue))
+        }
+        return try encoder.encode(event)
+    }
+
+    private static func snakeCased(_ value: String) -> String {
+        var result = ""
+        for character in value {
+            if character.isUppercase {
+                result.append("_")
+                result.append(contentsOf: character.lowercased())
+            } else {
+                result.append(character)
+            }
+        }
+        return result
+    }
+
+    private struct AnyCodingKey: CodingKey {
+        var stringValue: String
+        var intValue: Int? { nil }
+        init(stringValue: String) { self.stringValue = stringValue }
+        init?(intValue: Int) { nil }
+    }
+}
+
+struct SessionUpdateEvent: Encodable {
+    var type = "session.update"
+    var session: Session
+
+    struct Session: Encodable {
+        var type = "realtime"
+        var model: String
+        var instructions: String
+        var temperature: Double?
+        var maxOutputTokens: Int?
+        var outputModalities = ["audio", "text"]
+        var audio: Audio
+        var providerData: ProviderData?
+    }
+
+    struct ProviderData: Encodable {
+        var backchannel: Backchannel?
+        var responsiveness: Responsiveness?
+    }
+
+    struct Backchannel: Encodable {
+        var enabled = true
+        var maxPerTurn: Int
+        var minGapMs: Int
+        var minSpeechMs: Int
+        var volumeGain: Double
+        var deciderKind: String
+        var ruleFireProbability: Double?
+    }
+
+    struct Responsiveness: Encodable {
+        var enabled = true
+        var initialWaitTimeoutMs: Int
+        var maxInitialPerTurn: Int
+        var minFillerGapMs: Int
+        var maxTokens: Int
+        var enableFillerOnFirstAssistantReply: Bool
+    }
+
+    struct Audio: Encodable {
+        var input: Input
+        var output: Output
+    }
+
+    struct Input: Encodable {
+        var transcription: Transcription?
+        var noiseReduction: NoiseReduction?
+        var turnDetection: TurnDetection
+    }
+
+    struct Transcription: Encodable {
+        var model: String?
+        var language: String?
+    }
+
+    struct NoiseReduction: Encodable {
+        var type: String
+    }
+
+    struct TurnDetection: Encodable {
+        var type: String
+        // semantic_vad only
+        var eagerness: String?
+        // server_vad only
+        var threshold: Double?
+        var prefixPaddingMs: Int?
+        var silenceDurationMs: Int?
+        var idleTimeoutMs: Int?
+        var createResponse: Bool
+        var interruptResponse: Bool
+    }
+
+    struct Output: Encodable {
+        var model: String
+        var voice: String
+        var speed: Double?
+    }
+
+    init(config: SessionConfig) {
+        let turnDetection: TurnDetection
+        switch config.turnDetection {
+        case .semanticVAD(let eagerness):
+            turnDetection = TurnDetection(
+                type: "semantic_vad",
+                eagerness: eagerness,
+                createResponse: config.createResponse,
+                interruptResponse: config.interruptResponse
+            )
+        case .serverVAD(let threshold, let prefixPaddingMs, let silenceDurationMs, let idleTimeoutMs):
+            turnDetection = TurnDetection(
+                type: "server_vad",
+                threshold: threshold,
+                prefixPaddingMs: prefixPaddingMs,
+                silenceDurationMs: silenceDurationMs,
+                idleTimeoutMs: idleTimeoutMs,
+                createResponse: config.createResponse,
+                interruptResponse: config.interruptResponse
+            )
+        }
+
+        var transcription: Transcription?
+        if config.transcriptionModel != nil || config.transcriptionLanguage != nil {
+            transcription = Transcription(
+                model: config.transcriptionModel,
+                language: config.transcriptionLanguage
+            )
+        }
+
+        let backchannel = config.backchannel.map {
+            Backchannel(
+                maxPerTurn: $0.maxPerTurn,
+                minGapMs: $0.minGapMs,
+                minSpeechMs: $0.minSpeechMs,
+                volumeGain: $0.volumeGain,
+                deciderKind: $0.deciderKind,
+                ruleFireProbability: $0.deciderKind == "rule" ? $0.ruleFireProbability : nil
+            )
+        }
+        let responsiveness = config.responsiveness.map {
+            Responsiveness(
+                initialWaitTimeoutMs: $0.initialWaitTimeoutMs,
+                maxInitialPerTurn: $0.maxInitialPerTurn,
+                minFillerGapMs: $0.minFillerGapMs,
+                maxTokens: $0.maxTokens,
+                enableFillerOnFirstAssistantReply: $0.enableOnFirstReply
+            )
+        }
+        let providerData = (backchannel != nil || responsiveness != nil)
+            ? ProviderData(backchannel: backchannel, responsiveness: responsiveness)
+            : nil
+
+        session = Session(
+            model: config.model,
+            instructions: config.instructions,
+            temperature: config.temperature,
+            maxOutputTokens: config.maxOutputTokens,
+            audio: Audio(
+                input: Input(
+                    transcription: transcription,
+                    noiseReduction: config.noiseReduction.map(NoiseReduction.init(type:)),
+                    turnDetection: turnDetection
+                ),
+                output: Output(
+                    model: config.ttsModel,
+                    voice: config.voice,
+                    speed: config.speechSpeed
+                )
+            ),
+            providerData: providerData
+        )
+    }
+}
+
+struct ConversationItemCreateEvent: Encodable {
+    var type = "conversation.item.create"
+    var item: Item
+
+    struct Item: Encodable {
+        var type = "message"
+        var role = "user"
+        var content: [Content]
+    }
+
+    struct Content: Encodable {
+        var type = "input_text"
+        var text: String
+    }
+
+    init(userText: String) {
+        item = Item(content: [Content(text: userText)])
+    }
+}
+
+struct ResponseCreateEvent: Encodable {
+    var type = "response.create"
+}
+
+struct ResponseCancelEvent: Encodable {
+    var type = "response.cancel"
+}

--- a/realtime/ios/webrtc/Sources/Realtime/Events/ServerEvent.swift
+++ b/realtime/ios/webrtc/Sources/Realtime/Events/ServerEvent.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+enum ServerEvent: Equatable {
+    case outputTextDelta(String)
+    case transcriptDone(String?)
+    case inputTranscriptionDelta(String)
+    case inputTranscriptionCompleted(String)
+    case speechStarted
+    case outputItemAdded
+    case responseDone
+    case backchannelAudioDelta(base64PCM16: String)
+    case backchannelAudioDone(phrase: String?)
+    case backchannelSkipped(reason: String)
+    case error(String)
+    case unknown(type: String)
+
+    static func decode(_ data: Data) -> ServerEvent {
+        guard let obj = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+              let type = obj["type"] as? String else {
+            return .unknown(type: "")
+        }
+        switch type {
+        case "response.output_text.delta",
+             "response.text.delta",
+             "response.audio_transcript.delta",
+             "response.output_audio_transcript.delta":
+            return .outputTextDelta(obj["delta"] as? String ?? "")
+        case "response.output_audio_transcript.done":
+            return .transcriptDone(obj["transcript"] as? String)
+        case "response.content_part.done":
+            let part = obj["part"] as? [String: Any]
+            return .transcriptDone(part?["transcript"] as? String)
+        case "conversation.item.input_audio_transcription.delta":
+            return .inputTranscriptionDelta(obj["delta"] as? String ?? "")
+        case "conversation.item.input_audio_transcription.completed":
+            return .inputTranscriptionCompleted(obj["transcript"] as? String ?? "")
+        case "input_audio_buffer.speech_started":
+            return .speechStarted
+        case "response.output_item.added":
+            return .outputItemAdded
+        case "response.done":
+            return .responseDone
+        case "response.backchannel.audio.delta":
+            return .backchannelAudioDelta(base64PCM16: obj["delta"] as? String ?? "")
+        case "response.backchannel.audio.done":
+            return .backchannelAudioDone(phrase: obj["phrase"] as? String)
+        case "response.backchannel.skipped":
+            return .backchannelSkipped(reason: obj["reason"] as? String ?? "")
+        case "error":
+            let error = obj["error"] as? [String: Any]
+            let message = error?["message"] as? String ?? obj["message"] as? String ?? "unknown error"
+            return .error(message)
+        default:
+            return .unknown(type: type)
+        }
+    }
+}

--- a/realtime/ios/webrtc/Sources/Realtime/IceGatheringWaiter.swift
+++ b/realtime/ios/webrtc/Sources/Realtime/IceGatheringWaiter.swift
@@ -1,0 +1,57 @@
+import Foundation
+import WebRTC
+
+/// Waits for ICE gathering: resolves on `complete`, 500 ms of candidate silence,
+/// or a 3 s cap — mirroring the JS example. Candidates accumulate inside the
+/// peer connection's local description, so only the wait matters.
+final class IceGatheringWaiter {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var debounceTask: Task<Void, Never>?
+    private var timeoutTask: Task<Void, Never>?
+
+    func wait(peerConnection: RTCPeerConnection) async {
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            lock.lock()
+            continuation = cont
+            lock.unlock()
+            timeoutTask = Task { [weak self] in
+                try? await Task.sleep(for: .seconds(3))
+                guard !Task.isCancelled else { return }
+                self?.finish()
+            }
+            if peerConnection.iceGatheringState == .complete {
+                finish()
+            }
+        }
+    }
+
+    /// Called from the peer connection delegate (WebRTC signaling thread).
+    func candidateGenerated() {
+        lock.lock()
+        debounceTask?.cancel()
+        debounceTask = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(500))
+            guard !Task.isCancelled else { return }
+            self?.finish()
+        }
+        lock.unlock()
+    }
+
+    /// Called from the peer connection delegate (WebRTC signaling thread).
+    func gatheringStateChanged(_ state: RTCIceGatheringState) {
+        if state == .complete {
+            finish()
+        }
+    }
+
+    private func finish() {
+        lock.lock()
+        let cont = continuation
+        continuation = nil
+        debounceTask?.cancel()
+        timeoutTask?.cancel()
+        lock.unlock()
+        cont?.resume()
+    }
+}

--- a/realtime/ios/webrtc/Sources/Realtime/RealtimeSession.swift
+++ b/realtime/ios/webrtc/Sources/Realtime/RealtimeSession.swift
@@ -1,0 +1,172 @@
+import AVFoundation
+import Foundation
+import WebRTC
+
+enum SessionState: Equatable {
+    case idle
+    case connecting
+    case connected
+    case failed(String)
+}
+
+struct SessionConfig {
+    enum TurnDetection {
+        case semanticVAD(eagerness: String)
+        case serverVAD(threshold: Double?, prefixPaddingMs: Int?, silenceDurationMs: Int?, idleTimeoutMs: Int?)
+    }
+
+    struct BackchannelConfig {
+        var maxPerTurn: Int
+        var minGapMs: Int
+        var minSpeechMs: Int
+        var volumeGain: Double
+        var deciderKind: String
+        var ruleFireProbability: Double
+    }
+
+    struct ResponsivenessConfig {
+        var initialWaitTimeoutMs: Int
+        var maxInitialPerTurn: Int
+        var minFillerGapMs: Int
+        var maxTokens: Int
+        var enableOnFirstReply: Bool
+    }
+
+    var model: String
+    var instructions: String
+    var temperature: Double?
+    var maxOutputTokens: Int?
+
+    var ttsModel: String
+    var voice: String
+    var speechSpeed: Double?
+
+    var transcriptionModel: String?
+    var transcriptionLanguage: String?
+    var noiseReduction: String?
+    var turnDetection: TurnDetection = .semanticVAD(eagerness: "high")
+    var createResponse = true
+    var interruptResponse = true
+
+    var backchannel: BackchannelConfig?
+    var responsiveness: ResponsivenessConfig?
+
+    var greetingPrompt: String
+}
+
+@MainActor
+final class RealtimeSession {
+    private(set) var state: SessionState = .idle {
+        didSet { onStateChange?(state) }
+    }
+
+    var onStateChange: ((SessionState) -> Void)?
+    var onEvent: ((ServerEvent) -> Void)?
+
+    private let authProvider: AuthProvider
+    private let config: SessionConfig
+    private var client: WebRTCClient?
+    private let backchannelPlayer = BackchannelAudioPlayer()
+    private var interrupted = false
+
+    init(authProvider: AuthProvider, config: SessionConfig) {
+        self.authProvider = authProvider
+        self.config = config
+    }
+
+    func connect() async {
+        guard state == .idle || isFailed else { return }
+        state = .connecting
+        do {
+            guard await AVAudioApplication.requestRecordPermission() else {
+                state = .failed("Microphone access denied. Enable it in iOS Settings.")
+                return
+            }
+
+            let credentials = try await authProvider.credentials()
+            let api = SignalingAPI(credentials: credentials)
+            let iceServers = try await api.fetchIceServers()
+
+            let client = try WebRTCClient(iceServers: iceServers)
+            self.client = client
+            wireCallbacks(client)
+
+            let offerSDP = try await client.makeOfferSDP()
+            let answerSDP = try await api.postOffer(sdp: offerSDP)
+            try await client.setAnswer(sdp: answerSDP)
+            AudioSessionController.overrideToSpeaker()
+        } catch {
+            disconnect(failure: error.localizedDescription)
+        }
+    }
+
+    func disconnect(failure: String? = nil) {
+        client?.close()
+        client = nil
+        backchannelPlayer.stop()
+        interrupted = false
+        AudioSessionController.deactivate()
+        state = failure.map(SessionState.failed) ?? .idle
+    }
+
+    func setMicEnabled(_ enabled: Bool) {
+        client?.setMicEnabled(enabled)
+    }
+
+    private var isFailed: Bool {
+        if case .failed = state { return true }
+        return false
+    }
+
+    private func wireCallbacks(_ client: WebRTCClient) {
+        client.onDataChannelOpen = { [weak self] in
+            Task { @MainActor in self?.sendInitialEvents() }
+        }
+        client.onServerEvent = { [weak self] event in
+            Task { @MainActor in self?.handle(event) }
+        }
+        client.onConnectionStateChange = { [weak self] pcState in
+            Task { @MainActor in self?.handleConnectionState(pcState) }
+        }
+    }
+
+    private func sendInitialEvents() {
+        guard let client else { return }
+        client.send(SessionUpdateEvent(config: config))
+        client.send(ConversationItemCreateEvent(userText: config.greetingPrompt))
+        client.send(ResponseCreateEvent())
+        state = .connected
+    }
+
+    private func handle(_ event: ServerEvent) {
+        switch event {
+        case .speechStarted:
+            // Barge-in: silence the agent immediately, cancel its response.
+            interrupted = true
+            client?.setAgentAudioEnabled(false)
+            client?.send(ResponseCancelEvent())
+        case .outputItemAdded:
+            if interrupted {
+                client?.setAgentAudioEnabled(true)
+                interrupted = false
+            }
+        case .backchannelAudioDelta(let base64PCM16):
+            // Played independently of the WebRTC track so it stays audible during barge-in.
+            backchannelPlayer.enqueue(base64PCM16: base64PCM16)
+        default:
+            break
+        }
+        onEvent?(event)
+    }
+
+    private func handleConnectionState(_ pcState: RTCPeerConnectionState) {
+        switch pcState {
+        case .failed:
+            disconnect(failure: "Connection lost.")
+        case .disconnected, .closed:
+            if state == .connected { disconnect() }
+        default:
+            break
+        }
+    }
+}

--- a/realtime/ios/webrtc/Sources/Realtime/SignalingAPI.swift
+++ b/realtime/ios/webrtc/Sources/Realtime/SignalingAPI.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+enum SignalingError: LocalizedError {
+    case httpError(Int, String)
+    case malformedResponse
+
+    var errorDescription: String? {
+        switch self {
+        case .httpError(let status, let body):
+            "Inworld API error (HTTP \(status)): \(body.prefix(200))"
+        case .malformedResponse:
+            "Malformed response from Inworld API."
+        }
+    }
+}
+
+struct SignalingAPI {
+    var credentials: RealtimeCredentials
+    var session: URLSession = .shared
+
+    private struct IceServersResponse: Decodable {
+        var iceServers: [IceServer]
+
+        enum CodingKeys: String, CodingKey {
+            case iceServers = "ice_servers"
+        }
+    }
+
+    func fetchIceServers() async throws -> [IceServer] {
+        if let preFetched = credentials.preFetchedIceServers {
+            return preFetched
+        }
+        var request = URLRequest(url: credentials.apiBaseURL.appending(path: "v1/realtime/ice-servers"))
+        request.setValue(credentials.authorizationHeader, forHTTPHeaderField: "Authorization")
+        let data = try await perform(request)
+        return try JSONDecoder().decode(IceServersResponse.self, from: data).iceServers
+    }
+
+    func postOffer(sdp: String) async throws -> String {
+        let url = credentials.callsURL ?? credentials.apiBaseURL.appending(path: "v1/realtime/calls")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue(credentials.authorizationHeader, forHTTPHeaderField: "Authorization")
+        request.setValue("application/sdp", forHTTPHeaderField: "Content-Type")
+        request.httpBody = Data(sdp.utf8)
+        let data = try await perform(request)
+        guard let answer = String(data: data, encoding: .utf8), !answer.isEmpty else {
+            throw SignalingError.malformedResponse
+        }
+        return answer
+    }
+
+    private func perform(_ request: URLRequest) async throws -> Data {
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else { throw SignalingError.malformedResponse }
+        guard (200..<300).contains(http.statusCode) else {
+            throw SignalingError.httpError(http.statusCode, String(data: data, encoding: .utf8) ?? "")
+        }
+        return data
+    }
+}

--- a/realtime/ios/webrtc/Sources/Realtime/WebRTCClient.swift
+++ b/realtime/ios/webrtc/Sources/Realtime/WebRTCClient.swift
@@ -1,0 +1,141 @@
+import Foundation
+import WebRTC
+
+final class WebRTCClient: NSObject {
+    private static let factory: RTCPeerConnectionFactory = {
+        AudioSessionController.configureForVoiceChat()
+        RTCInitializeSSL()
+        return RTCPeerConnectionFactory()
+    }()
+
+    private let peerConnection: RTCPeerConnection
+    private let dataChannel: RTCDataChannel
+    private let localAudioTrack: RTCAudioTrack
+    private let iceWaiter = IceGatheringWaiter()
+    private var remoteAudioTrack: RTCAudioTrack?
+
+    var onDataChannelOpen: (() -> Void)?
+    var onServerEvent: ((ServerEvent) -> Void)?
+    var onConnectionStateChange: ((RTCPeerConnectionState) -> Void)?
+
+    init(iceServers: [IceServer]) throws {
+        let config = RTCConfiguration()
+        config.sdpSemantics = .unifiedPlan
+        config.iceServers = iceServers.map {
+            RTCIceServer(urlStrings: $0.urls, username: $0.username, credential: $0.credential)
+        }
+
+        let constraints = RTCMediaConstraints(mandatoryConstraints: nil, optionalConstraints: nil)
+        guard let pc = Self.factory.peerConnection(with: config, constraints: constraints, delegate: nil) else {
+            throw SignalingError.malformedResponse
+        }
+        peerConnection = pc
+
+        let dcConfig = RTCDataChannelConfiguration()
+        dcConfig.isOrdered = true
+        guard let dc = pc.dataChannel(forLabel: "oai-events", configuration: dcConfig) else {
+            throw SignalingError.malformedResponse
+        }
+        dataChannel = dc
+
+        let audioSource = Self.factory.audioSource(with: RTCMediaConstraints(
+            mandatoryConstraints: [
+                "googEchoCancellation": "true",
+                "googNoiseSuppression": "true",
+            ],
+            optionalConstraints: nil
+        ))
+        localAudioTrack = Self.factory.audioTrack(with: audioSource, trackId: "mic0")
+        pc.add(localAudioTrack, streamIds: ["stream0"])
+
+        super.init()
+        pc.delegate = self
+        dc.delegate = self
+    }
+
+    func makeOfferSDP() async throws -> String {
+        let constraints = RTCMediaConstraints(mandatoryConstraints: nil, optionalConstraints: nil)
+        let offer = try await peerConnection.offer(for: constraints)
+        try await peerConnection.setLocalDescription(offer)
+        await iceWaiter.wait(peerConnection: peerConnection)
+        guard let sdp = peerConnection.localDescription?.sdp else {
+            throw SignalingError.malformedResponse
+        }
+        return sdp
+    }
+
+    func setAnswer(sdp: String) async throws {
+        try await peerConnection.setRemoteDescription(RTCSessionDescription(type: .answer, sdp: sdp))
+    }
+
+    func send(_ event: some Encodable) {
+        guard dataChannel.readyState == .open,
+              let data = try? ClientEventEncoder.encode(event) else { return }
+        dataChannel.sendData(RTCDataBuffer(data: data, isBinary: false))
+    }
+
+    func setAgentAudioEnabled(_ enabled: Bool) {
+        remoteAudioTrack?.isEnabled = enabled
+    }
+
+    func setMicEnabled(_ enabled: Bool) {
+        localAudioTrack.isEnabled = enabled
+    }
+
+    func close() {
+        dataChannel.close()
+        peerConnection.close()
+    }
+}
+
+extension WebRTCClient: RTCPeerConnectionDelegate {
+    func peerConnection(_ peerConnection: RTCPeerConnection, didChange stateChanged: RTCSignalingState) {}
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didAdd stream: RTCMediaStream) {
+        if let track = stream.audioTracks.first {
+            remoteAudioTrack = track
+        }
+    }
+
+    func peerConnection(_ peerConnection: RTCPeerConnection,
+                        didAdd rtpReceiver: RTCRtpReceiver,
+                        streams mediaStreams: [RTCMediaStream]) {
+        if let track = rtpReceiver.track as? RTCAudioTrack {
+            remoteAudioTrack = track
+        }
+    }
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didRemove stream: RTCMediaStream) {}
+
+    func peerConnectionShouldNegotiate(_ peerConnection: RTCPeerConnection) {}
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didChange newState: RTCIceConnectionState) {}
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didChange newState: RTCIceGatheringState) {
+        iceWaiter.gatheringStateChanged(newState)
+    }
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didChange newState: RTCPeerConnectionState) {
+        onConnectionStateChange?(newState)
+    }
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didGenerate candidate: RTCIceCandidate) {
+        iceWaiter.candidateGenerated()
+    }
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didRemove candidates: [RTCIceCandidate]) {}
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didOpen dataChannel: RTCDataChannel) {}
+}
+
+extension WebRTCClient: RTCDataChannelDelegate {
+    func dataChannelDidChangeState(_ dataChannel: RTCDataChannel) {
+        if dataChannel.readyState == .open {
+            onDataChannelOpen?()
+        }
+    }
+
+    func dataChannel(_ dataChannel: RTCDataChannel, didReceiveMessageWith buffer: RTCDataBuffer) {
+        onServerEvent?(ServerEvent.decode(buffer.data))
+    }
+}

--- a/realtime/ios/webrtc/Sources/State/CatalogStore.swift
+++ b/realtime/ios/webrtc/Sources/State/CatalogStore.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class CatalogStore {
+    private(set) var models: [LLMModelInfo] = []
+    private(set) var voices: [VoiceInfo] = []
+    private(set) var isLoadingModels = false
+    private(set) var isLoadingVoices = false
+    private(set) var modelsError: String?
+    private(set) var voicesError: String?
+
+    private let settings: SettingsStore
+
+    init(settings: SettingsStore) {
+        self.settings = settings
+    }
+
+    func loadModels(force: Bool = false) async {
+        guard force || (models.isEmpty && !isLoadingModels) else { return }
+        isLoadingModels = true
+        modelsError = nil
+        defer { isLoadingModels = false }
+        do {
+            let credentials = try await settings.makeAuthProvider().credentials()
+            models = try await CatalogAPI(credentials: credentials).fetchModels()
+        } catch {
+            modelsError = error.localizedDescription
+        }
+    }
+
+    func loadVoices(force: Bool = false) async {
+        guard force || (voices.isEmpty && !isLoadingVoices) else { return }
+        isLoadingVoices = true
+        voicesError = nil
+        defer { isLoadingVoices = false }
+        do {
+            let credentials = try await settings.makeAuthProvider().credentials()
+            voices = try await CatalogAPI(credentials: credentials).fetchVoices()
+        } catch {
+            voicesError = error.localizedDescription
+        }
+    }
+}

--- a/realtime/ios/webrtc/Sources/State/ConversationViewModel.swift
+++ b/realtime/ios/webrtc/Sources/State/ConversationViewModel.swift
@@ -1,0 +1,151 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class ConversationViewModel {
+    private(set) var transcript: [TranscriptItem] = []
+    private(set) var state: SessionState = .idle
+    var isMicMuted = false {
+        didSet { session?.setMicEnabled(!isMicMuted) }
+    }
+
+    private let settings: SettingsStore
+    private var session: RealtimeSession?
+    private var streamingAgentItemID: UUID?
+    private var streamingUserItemID: UUID?
+
+    init(settings: SettingsStore) {
+        self.settings = settings
+    }
+
+    var isConnected: Bool { state == .connected }
+    var isBusy: Bool { state == .connecting }
+
+    var errorMessage: String? {
+        if case .failed(let message) = state { return message }
+        return nil
+    }
+
+    func connect() async {
+        transcript = []
+        streamingAgentItemID = nil
+        streamingUserItemID = nil
+        isMicMuted = false
+
+        let session = RealtimeSession(
+            authProvider: settings.makeAuthProvider(),
+            config: settings.makeSessionConfig()
+        )
+        session.onStateChange = { [weak self] state in self?.state = state }
+        session.onEvent = { [weak self] event in self?.handle(event) }
+        self.session = session
+        await session.connect()
+    }
+
+    func disconnect() {
+        session?.disconnect()
+        session = nil
+        streamingAgentItemID = nil
+        streamingUserItemID = nil
+    }
+
+    func handle(_ event: ServerEvent) {
+        switch event {
+        case .outputTextDelta(let delta):
+            appendAgentDelta(delta)
+        case .transcriptDone(let text):
+            finalizeAgentItem(replacingWith: text)
+        case .inputTranscriptionDelta(let delta):
+            appendUserDelta(delta)
+        case .inputTranscriptionCompleted(let transcript):
+            finalizeUserItem(with: transcript)
+        case .speechStarted:
+            dropStreamingAgentItem()
+        case .responseDone:
+            finalizeAgentItem(replacingWith: nil)
+        case .error(let message):
+            state = .failed(message)
+        case .outputItemAdded, .unknown,
+             .backchannelAudioDelta, .backchannelAudioDone, .backchannelSkipped:
+            // Back-channel audio is played in the realtime layer; phrase is telemetry, not transcript.
+            break
+        }
+    }
+
+    private func appendAgentDelta(_ delta: String) {
+        guard !delta.isEmpty else { return }
+        if let id = streamingAgentItemID, let index = transcript.firstIndex(where: { $0.id == id }) {
+            transcript[index].text += delta
+        } else {
+            var item = TranscriptItem(role: .agent, text: delta)
+            item.isStreaming = true
+            streamingAgentItemID = item.id
+            transcript.append(item)
+        }
+    }
+
+    private func finalizeAgentItem(replacingWith text: String?) {
+        guard let id = streamingAgentItemID,
+              let index = transcript.firstIndex(where: { $0.id == id }) else {
+            streamingAgentItemID = nil
+            return
+        }
+        if let text, !text.isEmpty {
+            transcript[index].text = text
+        }
+        transcript[index].isStreaming = false
+        streamingAgentItemID = nil
+    }
+
+    private func appendUserDelta(_ delta: String) {
+        guard !delta.isEmpty else { return }
+        if let id = streamingUserItemID, let index = transcript.firstIndex(where: { $0.id == id }) {
+            transcript[index].text = Self.reconcileTranscript(existing: transcript[index].text, delta: delta)
+        } else {
+            var item = TranscriptItem(role: .user, text: delta)
+            item.isStreaming = true
+            streamingUserItemID = item.id
+            transcript.append(item)
+        }
+    }
+
+    /// Some STT providers (e.g. Soniox) emit each partial as the FULL text-so-far rather
+    /// than an incremental chunk, so blindly appending duplicates the transcript. The
+    /// realtime contract intends `delta` to be incremental, but until the server normalizes
+    /// it, tolerate both shapes. The final `completed` transcript is authoritative regardless.
+    static func reconcileTranscript(existing: String, delta: String) -> String {
+        if existing.isEmpty { return delta }
+        if delta == existing { return existing }        // cumulative re-send of same text
+        if delta.hasPrefix(existing) { return delta }   // cumulative growth → replace
+        if existing.hasPrefix(delta) { return existing } // stale shorter snapshot → keep
+        return existing + delta                          // genuine incremental chunk → append
+    }
+
+    private func finalizeUserItem(with transcript: String) {
+        let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let id = streamingUserItemID, let index = self.transcript.firstIndex(where: { $0.id == id }) {
+            if !trimmed.isEmpty {
+                self.transcript[index].text = trimmed
+                self.transcript[index].isStreaming = false
+            } else if self.transcript[index].text.isEmpty {
+                // Nothing streamed and no final text: drop the empty bubble.
+                self.transcript.remove(at: index)
+            } else {
+                // Empty final but real partials arrived: keep them, just stop streaming.
+                self.transcript[index].isStreaming = false
+            }
+            streamingUserItemID = nil
+        } else if !trimmed.isEmpty {
+            // No partials arrived — append the final transcript directly.
+            self.transcript.append(TranscriptItem(role: .user, text: trimmed))
+        }
+    }
+
+    private func dropStreamingAgentItem() {
+        if let id = streamingAgentItemID {
+            transcript.removeAll { $0.id == id }
+            streamingAgentItemID = nil
+        }
+    }
+}

--- a/realtime/ios/webrtc/Sources/State/TranscriptItem.swift
+++ b/realtime/ios/webrtc/Sources/State/TranscriptItem.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct TranscriptItem: Identifiable, Equatable {
+    enum Role {
+        case user
+        case agent
+    }
+
+    let id = UUID()
+    var role: Role
+    var text: String
+    var isStreaming = false
+}

--- a/realtime/ios/webrtc/Sources/Storage/KeychainStore.swift
+++ b/realtime/ios/webrtc/Sources/Storage/KeychainStore.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Security
+
+struct KeychainStore {
+    let service: String
+
+    init(service: String = "ai.inworld.InworldVoiceAgent") {
+        self.service = service
+    }
+
+    func string(forKey key: String) -> String? {
+        var query = baseQuery(key: key)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        var result: AnyObject?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+              let data = result as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    func set(_ value: String, forKey key: String) {
+        let data = Data(value.utf8)
+        var query = baseQuery(key: key)
+        let attributes = [kSecValueData as String: data]
+        let status = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        if status == errSecItemNotFound {
+            query[kSecValueData as String] = data
+            SecItemAdd(query as CFDictionary, nil)
+        }
+    }
+
+    func remove(forKey key: String) {
+        SecItemDelete(baseQuery(key: key) as CFDictionary)
+    }
+
+    private func baseQuery(key: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+        ]
+    }
+}

--- a/realtime/ios/webrtc/Sources/Storage/KeychainStore.swift
+++ b/realtime/ios/webrtc/Sources/Storage/KeychainStore.swift
@@ -18,15 +18,18 @@ struct KeychainStore {
         return String(data: data, encoding: .utf8)
     }
 
-    func set(_ value: String, forKey key: String) {
+    @discardableResult
+    func set(_ value: String, forKey key: String) -> Bool {
         let data = Data(value.utf8)
         var query = baseQuery(key: key)
         let attributes = [kSecValueData as String: data]
         let status = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
         if status == errSecItemNotFound {
             query[kSecValueData as String] = data
-            SecItemAdd(query as CFDictionary, nil)
+            query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+            return SecItemAdd(query as CFDictionary, nil) == errSecSuccess
         }
+        return status == errSecSuccess
     }
 
     func remove(forKey key: String) {

--- a/realtime/ios/webrtc/Sources/Storage/SettingsStore.swift
+++ b/realtime/ios/webrtc/Sources/Storage/SettingsStore.swift
@@ -1,0 +1,237 @@
+import Foundation
+import Observation
+
+enum AuthMode: String, CaseIterable, Identifiable {
+    case basic
+    case backendJWT
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .basic: "API Key (Basic)"
+        case .backendJWT: "Backend JWT"
+        }
+    }
+}
+
+enum TurnDetectionMode: String, CaseIterable, Identifiable {
+    case semanticVAD = "semantic_vad"
+    case serverVAD = "server_vad"
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .semanticVAD: "Semantic VAD"
+        case .serverVAD: "Server VAD"
+        }
+    }
+}
+
+enum NoiseReductionMode: String, CaseIterable, Identifiable {
+    case off
+    case nearField = "near_field"
+    case farField = "far_field"
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .off: "Server default"
+        case .nearField: "Near field"
+        case .farField: "Far field"
+        }
+    }
+}
+
+enum DeciderKind: String, CaseIterable, Identifiable {
+    case llm
+    case rule
+
+    var id: String { rawValue }
+    var label: String { rawValue.uppercased() }
+}
+
+enum SettingsCatalog {
+    static let eagernessOptions = ["low", "medium", "high", "auto"]
+    static let transcriptionModels = [
+        "",  // server default
+        "inworld/inworld-stt-1",
+        "assemblyai/u3-rt-pro",
+        "soniox/stt-rt-v4",
+    ]
+}
+
+@Observable
+final class SettingsStore {
+    private static let apiKeyKeychainKey = "INWORLD_API_KEY"
+
+    private let keychain: KeychainStore
+    private let defaults: UserDefaults
+
+    var apiKey: String {
+        didSet {
+            if apiKey.isEmpty {
+                keychain.remove(forKey: Self.apiKeyKeychainKey)
+            } else {
+                keychain.set(apiKey, forKey: Self.apiKeyKeychainKey)
+            }
+        }
+    }
+
+    // Model
+    var model: String { didSet { defaults.set(model, forKey: "model") } }
+    var instructions: String { didSet { defaults.set(instructions, forKey: "instructions") } }
+    var greetingPrompt: String { didSet { defaults.set(greetingPrompt, forKey: "greetingPrompt") } }
+    var temperatureEnabled: Bool { didSet { defaults.set(temperatureEnabled, forKey: "temperatureEnabled") } }
+    var temperature: Double { didSet { defaults.set(temperature, forKey: "temperature") } }
+    /// 0 means "server default" (not sent).
+    var maxOutputTokens: Int { didSet { defaults.set(maxOutputTokens, forKey: "maxOutputTokens") } }
+
+    // Voice output
+    var ttsModel: String { didSet { defaults.set(ttsModel, forKey: "ttsModel") } }
+    var voice: String { didSet { defaults.set(voice, forKey: "voice") } }
+    var speechSpeed: Double { didSet { defaults.set(speechSpeed, forKey: "speechSpeed") } }
+
+    // Audio input
+    var transcriptionModel: String { didSet { defaults.set(transcriptionModel, forKey: "transcriptionModel") } }
+    var transcriptionLanguage: String { didSet { defaults.set(transcriptionLanguage, forKey: "transcriptionLanguage") } }
+    var noiseReduction: NoiseReductionMode { didSet { defaults.set(noiseReduction.rawValue, forKey: "noiseReduction") } }
+
+    // Turn detection
+    var turnDetectionMode: TurnDetectionMode { didSet { defaults.set(turnDetectionMode.rawValue, forKey: "turnDetectionMode") } }
+    var eagerness: String { didSet { defaults.set(eagerness, forKey: "eagerness") } }
+    var vadThreshold: Double { didSet { defaults.set(vadThreshold, forKey: "vadThreshold") } }
+    var prefixPaddingMs: Int { didSet { defaults.set(prefixPaddingMs, forKey: "prefixPaddingMs") } }
+    var silenceDurationMs: Int { didSet { defaults.set(silenceDurationMs, forKey: "silenceDurationMs") } }
+    /// 0 means "server default" (not sent).
+    var idleTimeoutMs: Int { didSet { defaults.set(idleTimeoutMs, forKey: "idleTimeoutMs") } }
+    var createResponse: Bool { didSet { defaults.set(createResponse, forKey: "createResponse") } }
+    var interruptResponse: Bool { didSet { defaults.set(interruptResponse, forKey: "interruptResponse") } }
+
+    // Back-channel (providerData.backchannel) — brief "uh-huh" interjections while the user speaks
+    var backchannelEnabled: Bool { didSet { defaults.set(backchannelEnabled, forKey: "backchannelEnabled") } }
+    var bcMaxPerTurn: Int { didSet { defaults.set(bcMaxPerTurn, forKey: "bcMaxPerTurn") } }
+    var bcMinGapMs: Int { didSet { defaults.set(bcMinGapMs, forKey: "bcMinGapMs") } }
+    var bcMinSpeechMs: Int { didSet { defaults.set(bcMinSpeechMs, forKey: "bcMinSpeechMs") } }
+    var bcVolumeGain: Double { didSet { defaults.set(bcVolumeGain, forKey: "bcVolumeGain") } }
+    var bcDeciderKind: DeciderKind { didSet { defaults.set(bcDeciderKind.rawValue, forKey: "bcDeciderKind") } }
+    var bcRuleFireProbability: Double { didSet { defaults.set(bcRuleFireProbability, forKey: "bcRuleFireProbability") } }
+
+    // Responsiveness (providerData.responsiveness) — low-latency filler before the main reply
+    var responsivenessEnabled: Bool { didSet { defaults.set(responsivenessEnabled, forKey: "responsivenessEnabled") } }
+    var respInitialWaitMs: Int { didSet { defaults.set(respInitialWaitMs, forKey: "respInitialWaitMs") } }
+    var respMaxInitialPerTurn: Int { didSet { defaults.set(respMaxInitialPerTurn, forKey: "respMaxInitialPerTurn") } }
+    var respMinFillerGapMs: Int { didSet { defaults.set(respMinFillerGapMs, forKey: "respMinFillerGapMs") } }
+    var respMaxTokens: Int { didSet { defaults.set(respMaxTokens, forKey: "respMaxTokens") } }
+    var respEnableOnFirstReply: Bool { didSet { defaults.set(respEnableOnFirstReply, forKey: "respEnableOnFirstReply") } }
+
+    // Auth
+    var authMode: AuthMode { didSet { defaults.set(authMode.rawValue, forKey: "authMode") } }
+    var backendURL: String { didSet { defaults.set(backendURL, forKey: "backendURL") } }
+
+    init(keychain: KeychainStore = KeychainStore(), defaults: UserDefaults = .standard) {
+        self.keychain = keychain
+        self.defaults = defaults
+        apiKey = keychain.string(forKey: Self.apiKeyKeychainKey) ?? Secrets.inworldAPIKey
+
+        model = defaults.string(forKey: "model") ?? "openai/gpt-4o-mini"
+        instructions = defaults.string(forKey: "instructions")
+            ?? "You are a friendly voice assistant. Keep responses brief."
+        greetingPrompt = defaults.string(forKey: "greetingPrompt")
+            ?? "Say hello and ask how you can help. One sentence max."
+        temperatureEnabled = defaults.bool(forKey: "temperatureEnabled")
+        temperature = defaults.object(forKey: "temperature") as? Double ?? 0.7
+        maxOutputTokens = defaults.integer(forKey: "maxOutputTokens")
+
+        ttsModel = defaults.string(forKey: "ttsModel") ?? "inworld-tts-2"
+        voice = defaults.string(forKey: "voice") ?? "Clive"
+        speechSpeed = defaults.object(forKey: "speechSpeed") as? Double ?? 1.0
+
+        transcriptionModel = defaults.string(forKey: "transcriptionModel") ?? ""
+        transcriptionLanguage = defaults.string(forKey: "transcriptionLanguage") ?? ""
+        noiseReduction = NoiseReductionMode(rawValue: defaults.string(forKey: "noiseReduction") ?? "") ?? .off
+
+        turnDetectionMode = TurnDetectionMode(rawValue: defaults.string(forKey: "turnDetectionMode") ?? "") ?? .semanticVAD
+        eagerness = defaults.string(forKey: "eagerness") ?? "high"
+        vadThreshold = defaults.object(forKey: "vadThreshold") as? Double ?? 0.5
+        prefixPaddingMs = defaults.object(forKey: "prefixPaddingMs") as? Int ?? 300
+        silenceDurationMs = defaults.object(forKey: "silenceDurationMs") as? Int ?? 500
+        idleTimeoutMs = defaults.integer(forKey: "idleTimeoutMs")
+        createResponse = defaults.object(forKey: "createResponse") as? Bool ?? true
+        interruptResponse = defaults.object(forKey: "interruptResponse") as? Bool ?? true
+
+        backchannelEnabled = defaults.bool(forKey: "backchannelEnabled")
+        bcMaxPerTurn = defaults.object(forKey: "bcMaxPerTurn") as? Int ?? 3
+        bcMinGapMs = defaults.object(forKey: "bcMinGapMs") as? Int ?? 4000
+        bcMinSpeechMs = defaults.object(forKey: "bcMinSpeechMs") as? Int ?? 800
+        bcVolumeGain = defaults.object(forKey: "bcVolumeGain") as? Double ?? 0.6
+        bcDeciderKind = DeciderKind(rawValue: defaults.string(forKey: "bcDeciderKind") ?? "") ?? .llm
+        bcRuleFireProbability = defaults.object(forKey: "bcRuleFireProbability") as? Double ?? 1.0
+
+        responsivenessEnabled = defaults.bool(forKey: "responsivenessEnabled")
+        respInitialWaitMs = defaults.object(forKey: "respInitialWaitMs") as? Int ?? 1200
+        respMaxInitialPerTurn = defaults.object(forKey: "respMaxInitialPerTurn") as? Int ?? 1
+        respMinFillerGapMs = defaults.object(forKey: "respMinFillerGapMs") as? Int ?? 8000
+        respMaxTokens = defaults.object(forKey: "respMaxTokens") as? Int ?? 12
+        respEnableOnFirstReply = defaults.bool(forKey: "respEnableOnFirstReply")
+
+        authMode = AuthMode(rawValue: defaults.string(forKey: "authMode") ?? "") ?? .basic
+        backendURL = defaults.string(forKey: "backendURL") ?? "http://localhost:3000"
+    }
+
+    func makeAuthProvider() -> AuthProvider {
+        switch authMode {
+        case .basic:
+            BasicAuthProvider(apiKey: apiKey)
+        case .backendJWT:
+            BackendJWTAuthProvider(backendURL: backendURL)
+        }
+    }
+
+    func makeSessionConfig() -> SessionConfig {
+        let turnDetection: SessionConfig.TurnDetection = switch turnDetectionMode {
+        case .semanticVAD:
+            .semanticVAD(eagerness: eagerness)
+        case .serverVAD:
+            .serverVAD(
+                threshold: vadThreshold,
+                prefixPaddingMs: prefixPaddingMs,
+                silenceDurationMs: silenceDurationMs,
+                idleTimeoutMs: idleTimeoutMs > 0 ? idleTimeoutMs : nil
+            )
+        }
+        return SessionConfig(
+            model: model,
+            instructions: instructions,
+            temperature: temperatureEnabled ? temperature : nil,
+            maxOutputTokens: maxOutputTokens > 0 ? maxOutputTokens : nil,
+            ttsModel: ttsModel,
+            voice: voice,
+            speechSpeed: speechSpeed == 1.0 ? nil : speechSpeed,
+            transcriptionModel: transcriptionModel.isEmpty ? nil : transcriptionModel,
+            transcriptionLanguage: transcriptionLanguage.isEmpty ? nil : transcriptionLanguage,
+            noiseReduction: noiseReduction == .off ? nil : noiseReduction.rawValue,
+            turnDetection: turnDetection,
+            createResponse: createResponse,
+            interruptResponse: interruptResponse,
+            backchannel: backchannelEnabled ? SessionConfig.BackchannelConfig(
+                maxPerTurn: bcMaxPerTurn,
+                minGapMs: bcMinGapMs,
+                minSpeechMs: bcMinSpeechMs,
+                volumeGain: bcVolumeGain,
+                deciderKind: bcDeciderKind.rawValue,
+                ruleFireProbability: bcRuleFireProbability
+            ) : nil,
+            responsiveness: responsivenessEnabled ? SessionConfig.ResponsivenessConfig(
+                initialWaitTimeoutMs: respInitialWaitMs,
+                maxInitialPerTurn: respMaxInitialPerTurn,
+                minFillerGapMs: respMinFillerGapMs,
+                maxTokens: respMaxTokens,
+                enableOnFirstReply: respEnableOnFirstReply
+            ) : nil,
+            greetingPrompt: greetingPrompt
+        )
+    }
+}

--- a/realtime/ios/webrtc/Sources/Views/CatalogPickerViews.swift
+++ b/realtime/ios/webrtc/Sources/Views/CatalogPickerViews.swift
@@ -1,0 +1,173 @@
+import SwiftUI
+
+struct ModelPickerView: View {
+    @Environment(AppModel.self) private var model
+    @Environment(\.dismiss) private var dismiss
+    @Binding var selection: String
+
+    private var supportedModels: [LLMModelInfo] {
+        model.catalog.models.filter { $0.isSupported != false }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if model.catalog.isLoadingModels && model.catalog.models.isEmpty {
+                    ProgressView("Loading models…")
+                } else if let error = model.catalog.modelsError, model.catalog.models.isEmpty {
+                    CatalogErrorView(message: error) {
+                        Task { await model.catalog.loadModels(force: true) }
+                    }
+                } else {
+                    List(supportedModels) { item in
+                        Button {
+                            selection = item.realtimeIdentifier
+                            dismiss()
+                        } label: {
+                            row(for: item)
+                        }
+                        .tint(.primary)
+                    }
+                }
+            }
+            .navigationTitle("Models")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        Task { await model.catalog.loadModels(force: true) }
+                    } label: {
+                        Image(systemName: "arrow.clockwise")
+                    }
+                }
+            }
+        }
+        .task { await model.catalog.loadModels() }
+    }
+
+    private func row(for item: LLMModelInfo) -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.realtimeIdentifier)
+                Text(subtitle(for: item)).font(.caption).foregroundStyle(.secondary)
+            }
+            Spacer()
+            if item.realtimeIdentifier == selection {
+                Image(systemName: "checkmark").foregroundStyle(.tint)
+            }
+        }
+    }
+
+    private func subtitle(for item: LLMModelInfo) -> String {
+        var parts: [String] = []
+        if let provider = item.provider, !provider.isEmpty {
+            parts.append("Provider: \(provider)")
+        }
+        if let creator = item.modelCreator, !creator.isEmpty {
+            parts.append(creator)
+        }
+        return parts.joined(separator: " · ")
+    }
+}
+
+struct VoicePickerView: View {
+    @Environment(AppModel.self) private var model
+    @Environment(\.dismiss) private var dismiss
+    @Binding var selection: String
+    @State private var query = ""
+
+    private var filteredVoices: [VoiceInfo] {
+        let voices = model.catalog.voices
+        guard !query.isEmpty else { return voices }
+        let q = query.lowercased()
+        return voices.filter {
+            ($0.displayName ?? $0.voiceId).lowercased().contains(q)
+                || $0.voiceId.lowercased().contains(q)
+                || ($0.langCode ?? "").lowercased().contains(q)
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if model.catalog.isLoadingVoices && model.catalog.voices.isEmpty {
+                    ProgressView("Loading voices…")
+                } else if let error = model.catalog.voicesError, model.catalog.voices.isEmpty {
+                    CatalogErrorView(message: error) {
+                        Task { await model.catalog.loadVoices(force: true) }
+                    }
+                } else {
+                    List(filteredVoices) { voice in
+                        Button {
+                            selection = voice.voiceId
+                            dismiss()
+                        } label: {
+                            row(for: voice)
+                        }
+                        .tint(.primary)
+                    }
+                    .searchable(text: $query, prompt: "Search voices")
+                }
+            }
+            .navigationTitle("Voices")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        Task { await model.catalog.loadVoices(force: true) }
+                    } label: {
+                        Image(systemName: "arrow.clockwise")
+                    }
+                }
+            }
+        }
+        .task { await model.catalog.loadVoices() }
+    }
+
+    private func row(for voice: VoiceInfo) -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(voice.displayName ?? voice.voiceId)
+                Text(voiceSubtitle(voice))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            if voice.voiceId == selection {
+                Image(systemName: "checkmark").foregroundStyle(.tint)
+            }
+        }
+    }
+
+    private func voiceSubtitle(_ voice: VoiceInfo) -> String {
+        [voice.langCode, voice.gender, voice.source]
+            .compactMap { $0?.isEmpty == false ? $0 : nil }
+            .joined(separator: " · ")
+    }
+}
+
+private struct CatalogErrorView: View {
+    let message: String
+    let retry: () -> Void
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.largeTitle)
+                .foregroundStyle(.secondary)
+            Text(message)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+            Button("Retry", action: retry)
+                .buttonStyle(.bordered)
+        }
+        .padding()
+    }
+}

--- a/realtime/ios/webrtc/Sources/Views/ConnectionControlsView.swift
+++ b/realtime/ios/webrtc/Sources/Views/ConnectionControlsView.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+struct ConnectionControlsView: View {
+    @Environment(AppModel.self) private var model
+
+    var body: some View {
+        @Bindable var conversation = model.conversation
+        VStack(spacing: 10) {
+            if let error = conversation.errorMessage {
+                Text(error)
+                    .font(.footnote)
+                    .foregroundStyle(.red)
+                    .multilineTextAlignment(.center)
+            }
+            HStack(spacing: 16) {
+                statusPill
+                Spacer()
+                if conversation.isConnected {
+                    Button {
+                        conversation.isMicMuted.toggle()
+                    } label: {
+                        Image(systemName: conversation.isMicMuted ? "mic.slash.fill" : "mic.fill")
+                            .font(.title3)
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(conversation.isMicMuted ? .red : .accentColor)
+                }
+                connectButton
+            }
+        }
+        .padding()
+    }
+
+    private var statusPill: some View {
+        Label(statusText, systemImage: "circle.fill")
+            .font(.caption)
+            .foregroundStyle(statusColor)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(statusColor.opacity(0.12), in: Capsule())
+    }
+
+    private var statusText: String {
+        switch model.conversation.state {
+        case .idle: "Disconnected"
+        case .connecting: "Connecting…"
+        case .connected: "Connected"
+        case .failed: "Error"
+        }
+    }
+
+    private var statusColor: Color {
+        switch model.conversation.state {
+        case .idle: .secondary
+        case .connecting: .orange
+        case .connected: .green
+        case .failed: .red
+        }
+    }
+
+    private var connectButton: some View {
+        Button {
+            if model.conversation.isConnected || model.conversation.isBusy {
+                model.conversation.disconnect()
+            } else {
+                Task { await model.conversation.connect() }
+            }
+        } label: {
+            Text(model.conversation.isConnected || model.conversation.isBusy ? "Disconnect" : "Connect")
+                .frame(minWidth: 100)
+        }
+        .buttonStyle(.borderedProminent)
+        .tint(model.conversation.isConnected || model.conversation.isBusy ? .red : .accentColor)
+    }
+}

--- a/realtime/ios/webrtc/Sources/Views/ConversationView.swift
+++ b/realtime/ios/webrtc/Sources/Views/ConversationView.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+struct ConversationView: View {
+    @Environment(AppModel.self) private var model
+    @State private var showsSettings = false
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                transcriptList
+                Divider()
+                ConnectionControlsView()
+            }
+            .navigationTitle("Inworld Voice")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        showsSettings = true
+                    } label: {
+                        Image(systemName: "gearshape")
+                    }
+                }
+            }
+            .sheet(isPresented: $showsSettings) {
+                SettingsView()
+            }
+        }
+    }
+
+    private var transcriptList: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: 12) {
+                    if model.conversation.transcript.isEmpty {
+                        emptyState
+                    }
+                    ForEach(model.conversation.transcript) { item in
+                        MessageBubbleView(item: item)
+                            .id(item.id)
+                    }
+                }
+                .padding()
+            }
+            .onChange(of: model.conversation.transcript) {
+                if let last = model.conversation.transcript.last {
+                    withAnimation(.easeOut(duration: 0.2)) {
+                        proxy.scrollTo(last.id, anchor: .bottom)
+                    }
+                }
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "waveform.circle")
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+            Text(model.conversation.isConnected
+                 ? "Listening — just start talking."
+                 : "Connect to start a voice conversation.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.top, 80)
+    }
+}

--- a/realtime/ios/webrtc/Sources/Views/ConversationView.swift
+++ b/realtime/ios/webrtc/Sources/Views/ConversationView.swift
@@ -43,10 +43,10 @@ struct ConversationView: View {
                 .padding()
             }
             .onChange(of: model.conversation.transcript) {
+                // No withAnimation: transcript mutates on every streaming delta, and
+                // animating each scroll causes jank during token-by-token output.
                 if let last = model.conversation.transcript.last {
-                    withAnimation(.easeOut(duration: 0.2)) {
-                        proxy.scrollTo(last.id, anchor: .bottom)
-                    }
+                    proxy.scrollTo(last.id, anchor: .bottom)
                 }
             }
         }

--- a/realtime/ios/webrtc/Sources/Views/MessageBubbleView.swift
+++ b/realtime/ios/webrtc/Sources/Views/MessageBubbleView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct MessageBubbleView: View {
+    let item: TranscriptItem
+
+    private var isUser: Bool { item.role == .user }
+
+    var body: some View {
+        HStack {
+            if isUser { Spacer(minLength: 48) }
+            VStack(alignment: .leading, spacing: 4) {
+                Text(item.text)
+                if item.isStreaming {
+                    ProgressView()
+                        .controlSize(.mini)
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(isUser ? Color.accentColor : Color(.secondarySystemBackground))
+            .foregroundStyle(isUser ? .white : .primary)
+            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+            if !isUser { Spacer(minLength: 48) }
+        }
+    }
+}

--- a/realtime/ios/webrtc/Sources/Views/SettingsView.swift
+++ b/realtime/ios/webrtc/Sources/Views/SettingsView.swift
@@ -1,0 +1,265 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @Environment(AppModel.self) private var model
+    @Environment(\.dismiss) private var dismiss
+    @State private var showsModelPicker = false
+    @State private var showsVoicePicker = false
+
+    var body: some View {
+        @Bindable var settings = model.settings
+        NavigationStack {
+            Form {
+                authSection($settings)
+                modelSection($settings)
+                voiceSection($settings)
+                inputSection($settings)
+                turnDetectionSection($settings)
+                backchannelSection($settings)
+                responsivenessSection($settings)
+                instructionsSection($settings)
+            }
+            .navigationTitle("Settings")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            .sheet(isPresented: $showsModelPicker) {
+                ModelPickerView(selection: $settings.model)
+            }
+            .sheet(isPresented: $showsVoicePicker) {
+                VoicePickerView(selection: $settings.voice)
+            }
+        }
+    }
+
+    private func authSection(_ settings: Bindable<SettingsStore>) -> some View {
+        Section("Authentication") {
+            Picker("Mode", selection: settings.authMode) {
+                ForEach(AuthMode.allCases) { mode in
+                    Text(mode.label).tag(mode)
+                }
+            }
+            switch settings.wrappedValue.authMode {
+            case .basic:
+                SecureField("Inworld API Key (base64)", text: settings.apiKey)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+            case .backendJWT:
+                TextField("Backend URL", text: settings.backendURL)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .keyboardType(.URL)
+            }
+        }
+    }
+
+    private func modelSection(_ settings: Bindable<SettingsStore>) -> some View {
+        Section("Model") {
+            TextField("LLM model", text: settings.model)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+            Button {
+                showsModelPicker = true
+            } label: {
+                Label("Browse available models", systemImage: "list.bullet")
+            }
+            Toggle("Custom temperature", isOn: settings.temperatureEnabled)
+            if settings.wrappedValue.temperatureEnabled {
+                LabeledSlider(
+                    label: "Temperature",
+                    value: settings.temperature,
+                    range: 0...2,
+                    step: 0.1,
+                    format: "%.1f"
+                )
+            }
+            Stepper(
+                settings.wrappedValue.maxOutputTokens > 0
+                    ? "Max tokens: \(settings.wrappedValue.maxOutputTokens)"
+                    : "Max tokens: default",
+                value: settings.maxOutputTokens,
+                in: 0...4096,
+                step: 256
+            )
+        }
+    }
+
+    private func voiceSection(_ settings: Bindable<SettingsStore>) -> some View {
+        Section("Voice Output") {
+            TextField("TTS model", text: settings.ttsModel)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+            TextField("Voice", text: settings.voice)
+                .autocorrectionDisabled()
+            Button {
+                showsVoicePicker = true
+            } label: {
+                Label("Browse available voices", systemImage: "person.wave.2")
+            }
+            LabeledSlider(
+                label: "Speed",
+                value: settings.speechSpeed,
+                range: 0.25...1.5,
+                step: 0.05,
+                format: "%.2f×"
+            )
+        }
+    }
+
+    private func inputSection(_ settings: Bindable<SettingsStore>) -> some View {
+        Section("Audio Input") {
+            Picker("Transcription", selection: settings.transcriptionModel) {
+                ForEach(SettingsCatalog.transcriptionModels, id: \.self) { model in
+                    Text(model.isEmpty ? "Server default" : model).tag(model)
+                }
+            }
+            TextField("Language (e.g. en, optional)", text: settings.transcriptionLanguage)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+            Picker("Noise reduction", selection: settings.noiseReduction) {
+                ForEach(NoiseReductionMode.allCases) { mode in
+                    Text(mode.label).tag(mode)
+                }
+            }
+        }
+    }
+
+    private func turnDetectionSection(_ settings: Bindable<SettingsStore>) -> some View {
+        Section {
+            Picker("Type", selection: settings.turnDetectionMode) {
+                ForEach(TurnDetectionMode.allCases) { mode in
+                    Text(mode.label).tag(mode)
+                }
+            }
+            switch settings.wrappedValue.turnDetectionMode {
+            case .semanticVAD:
+                Picker("Eagerness", selection: settings.eagerness) {
+                    ForEach(SettingsCatalog.eagernessOptions, id: \.self) { option in
+                        Text(option.capitalized).tag(option)
+                    }
+                }
+            case .serverVAD:
+                LabeledSlider(
+                    label: "Threshold",
+                    value: settings.vadThreshold,
+                    range: 0...1,
+                    step: 0.05,
+                    format: "%.2f"
+                )
+                Stepper(
+                    "Prefix padding: \(settings.wrappedValue.prefixPaddingMs) ms",
+                    value: settings.prefixPaddingMs,
+                    in: 0...2000,
+                    step: 100
+                )
+                Stepper(
+                    "Silence duration: \(settings.wrappedValue.silenceDurationMs) ms",
+                    value: settings.silenceDurationMs,
+                    in: 100...3000,
+                    step: 100
+                )
+                Stepper(
+                    settings.wrappedValue.idleTimeoutMs > 0
+                        ? "Idle timeout: \(settings.wrappedValue.idleTimeoutMs) ms"
+                        : "Idle timeout: off",
+                    value: settings.idleTimeoutMs,
+                    in: 0...30000,
+                    step: 1000
+                )
+            }
+            Toggle("Auto-create response", isOn: settings.createResponse)
+            Toggle("Allow interruptions", isOn: settings.interruptResponse)
+        } header: {
+            Text("Turn Detection")
+        } footer: {
+            Text(settings.wrappedValue.turnDetectionMode == .semanticVAD
+                 ? "Semantic VAD uses meaning to detect end of turn."
+                 : "Server VAD uses audio levels and silence timing.")
+        }
+    }
+
+    @ViewBuilder
+    private func backchannelSection(_ settings: Bindable<SettingsStore>) -> some View {
+        Section {
+            Toggle("Enable back-channel", isOn: settings.backchannelEnabled)
+            if settings.wrappedValue.backchannelEnabled {
+                Picker("Decider", selection: settings.bcDeciderKind) {
+                    ForEach(DeciderKind.allCases) { kind in
+                        Text(kind.label).tag(kind)
+                    }
+                }
+                if settings.wrappedValue.bcDeciderKind == .rule {
+                    LabeledSlider(label: "Fire probability", value: settings.bcRuleFireProbability,
+                                  range: 0...1, step: 0.05, format: "%.2f")
+                }
+                Stepper("Max per turn: \(settings.wrappedValue.bcMaxPerTurn)",
+                        value: settings.bcMaxPerTurn, in: 1...10)
+                Stepper("Min gap: \(settings.wrappedValue.bcMinGapMs) ms",
+                        value: settings.bcMinGapMs, in: 0...10000, step: 500)
+                Stepper("Min speech: \(settings.wrappedValue.bcMinSpeechMs) ms",
+                        value: settings.bcMinSpeechMs, in: 0...5000, step: 100)
+                LabeledSlider(label: "Volume gain", value: settings.bcVolumeGain,
+                              range: 0...1, step: 0.05, format: "%.2f")
+            }
+        } header: {
+            Text("Back-channel")
+        } footer: {
+            Text("Brief acknowledgements (\u{201C}uh-huh\u{201D}, \u{201C}right\u{201D}) emitted while you are speaking.")
+        }
+    }
+
+    @ViewBuilder
+    private func responsivenessSection(_ settings: Bindable<SettingsStore>) -> some View {
+        Section {
+            Toggle("Enable responsiveness", isOn: settings.responsivenessEnabled)
+            if settings.wrappedValue.responsivenessEnabled {
+                Stepper("Initial wait: \(settings.wrappedValue.respInitialWaitMs) ms",
+                        value: settings.respInitialWaitMs, in: 0...5000, step: 100)
+                Stepper("Max initial per turn: \(settings.wrappedValue.respMaxInitialPerTurn)",
+                        value: settings.respMaxInitialPerTurn, in: 0...5)
+                Stepper("Min filler gap: \(settings.wrappedValue.respMinFillerGapMs) ms",
+                        value: settings.respMinFillerGapMs, in: 0...20000, step: 1000)
+                Stepper("Max tokens: \(settings.wrappedValue.respMaxTokens)",
+                        value: settings.respMaxTokens, in: 1...50)
+                Toggle("Allow on first reply", isOn: settings.respEnableOnFirstReply)
+            }
+        } header: {
+            Text("Responsiveness")
+        } footer: {
+            Text("Low-latency filler spoken before the main answer while the model is still thinking.")
+        }
+    }
+
+    private func instructionsSection(_ settings: Bindable<SettingsStore>) -> some View {
+        Section("Instructions") {
+            TextField("System instructions", text: settings.instructions, axis: .vertical)
+                .lineLimit(3...6)
+            TextField("Greeting prompt", text: settings.greetingPrompt, axis: .vertical)
+                .lineLimit(2...4)
+        }
+    }
+}
+
+private struct LabeledSlider: View {
+    let label: String
+    @Binding var value: Double
+    let range: ClosedRange<Double>
+    let step: Double
+    let format: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(label)
+                Spacer()
+                Text(String(format: format, value))
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+            Slider(value: $value, in: range, step: step)
+        }
+    }
+}

--- a/realtime/ios/webrtc/Tests/BackchannelAudioPlayerTests.swift
+++ b/realtime/ios/webrtc/Tests/BackchannelAudioPlayerTests.swift
@@ -1,0 +1,22 @@
+import AVFoundation
+import XCTest
+@testable import InworldVoiceAgent
+
+final class BackchannelAudioPlayerTests: XCTestCase {
+    private let format = AVAudioFormat(standardFormatWithSampleRate: 24000, channels: 1)!
+
+    func testPCM16DecodesToExpectedFrameCountAndValues() throws {
+        // Two little-endian Int16 samples: 0 and 16384 (= 0.5 in float).
+        let pcm16 = Data([0x00, 0x00, 0x00, 0x40])
+        let buffer = try XCTUnwrap(BackchannelAudioPlayer.makeBuffer(from: pcm16, format: format))
+
+        XCTAssertEqual(buffer.frameLength, 2)
+        let channel = try XCTUnwrap(buffer.floatChannelData)
+        XCTAssertEqual(channel[0][0], 0.0, accuracy: 0.0001)
+        XCTAssertEqual(channel[0][1], 0.5, accuracy: 0.0001)
+    }
+
+    func testEmptyDataYieldsNoBuffer() {
+        XCTAssertNil(BackchannelAudioPlayer.makeBuffer(from: Data(), format: format))
+    }
+}

--- a/realtime/ios/webrtc/Tests/CatalogDecodingTests.swift
+++ b/realtime/ios/webrtc/Tests/CatalogDecodingTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import InworldVoiceAgent
+
+final class CatalogDecodingTests: XCTestCase {
+    func testModelDecodingAndRealtimeIdentifier() throws {
+        let json = #"""
+        {"model": "gemini-2.5-flash", "provider": "google", "modelCreator": "Google", "isSupported": true}
+        """#
+        let model = try JSONDecoder().decode(LLMModelInfo.self, from: Data(json.utf8))
+        XCTAssertEqual(model.model, "gemini-2.5-flash")
+        XCTAssertEqual(model.provider, "google")
+        XCTAssertEqual(model.realtimeIdentifier, "google/gemini-2.5-flash")
+    }
+
+    func testRealtimeIdentifierLeavesPrefixedModelUntouched() {
+        let model = LLMModelInfo(model: "openai/gpt-4o-mini", provider: "openai")
+        XCTAssertEqual(model.realtimeIdentifier, "openai/gpt-4o-mini")
+    }
+
+    func testRealtimeIdentifierWithoutProvider() {
+        let model = LLMModelInfo(model: "gpt-4o-mini", provider: nil)
+        XCTAssertEqual(model.realtimeIdentifier, "gpt-4o-mini")
+    }
+
+    func testRealtimeIdentifierPrefixesProviderWhenModelHasSlash() {
+        // Inworld- and deepinfra-served models carry slashes in the model string itself.
+        XCTAssertEqual(
+            LLMModelInfo(model: "models/GLM-5.1", provider: "inworld").realtimeIdentifier,
+            "inworld/models/GLM-5.1"
+        )
+        XCTAssertEqual(
+            LLMModelInfo(model: "MiniMaxAI/MiniMax-M2.5", provider: "deepinfra").realtimeIdentifier,
+            "deepinfra/MiniMaxAI/MiniMax-M2.5"
+        )
+    }
+
+    func testVoiceDecoding() throws {
+        let json = #"""
+        {"name": "workspaces/inworld/voices/Alex", "voiceId": "Alex", "langCode": "EN_US",
+         "displayName": "Alex", "gender": "male", "source": "SYSTEM"}
+        """#
+        let voice = try JSONDecoder().decode(VoiceInfo.self, from: Data(json.utf8))
+        XCTAssertEqual(voice.voiceId, "Alex")
+        XCTAssertEqual(voice.displayName, "Alex")
+        XCTAssertEqual(voice.langCode, "EN_US")
+        XCTAssertEqual(voice.gender, "male")
+        XCTAssertEqual(voice.source, "SYSTEM")
+    }
+}

--- a/realtime/ios/webrtc/Tests/ClientEventEncodingTests.swift
+++ b/realtime/ios/webrtc/Tests/ClientEventEncodingTests.swift
@@ -1,0 +1,199 @@
+import XCTest
+@testable import InworldVoiceAgent
+
+final class ClientEventEncodingTests: XCTestCase {
+    private func encodeToDictionary(_ event: some Encodable) throws -> [String: Any] {
+        let data = try ClientEventEncoder.encode(event)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private func makeBaseConfig() -> SessionConfig {
+        SessionConfig(
+            model: "openai/gpt-4o-mini",
+            instructions: "Be brief.",
+            ttsModel: "inworld-tts-2",
+            voice: "Clive",
+            greetingPrompt: "Say hello."
+        )
+    }
+
+    func testSessionUpdateDefaultShape() throws {
+        let json = try encodeToDictionary(SessionUpdateEvent(config: makeBaseConfig()))
+
+        XCTAssertEqual(json["type"] as? String, "session.update")
+        let session = try XCTUnwrap(json["session"] as? [String: Any])
+        XCTAssertEqual(session["type"] as? String, "realtime")
+        XCTAssertEqual(session["model"] as? String, "openai/gpt-4o-mini")
+        XCTAssertEqual(session["instructions"] as? String, "Be brief.")
+        XCTAssertEqual(session["output_modalities"] as? [String], ["audio", "text"])
+        XCTAssertNil(session["temperature"])
+        XCTAssertNil(session["max_output_tokens"])
+
+        let audio = try XCTUnwrap(session["audio"] as? [String: Any])
+        let input = try XCTUnwrap(audio["input"] as? [String: Any])
+        XCTAssertNil(input["transcription"])
+        XCTAssertNil(input["noise_reduction"])
+
+        let turnDetection = try XCTUnwrap(input["turn_detection"] as? [String: Any])
+        XCTAssertEqual(turnDetection["type"] as? String, "semantic_vad")
+        XCTAssertEqual(turnDetection["eagerness"] as? String, "high")
+        XCTAssertEqual(turnDetection["create_response"] as? Bool, true)
+        XCTAssertEqual(turnDetection["interrupt_response"] as? Bool, true)
+        XCTAssertNil(turnDetection["threshold"])
+
+        let output = try XCTUnwrap(audio["output"] as? [String: Any])
+        XCTAssertEqual(output["model"] as? String, "inworld-tts-2")
+        XCTAssertEqual(output["voice"] as? String, "Clive")
+        XCTAssertNil(output["speed"])
+    }
+
+    func testSessionUpdateWithAllOptions() throws {
+        var config = makeBaseConfig()
+        config.temperature = 0.9
+        config.maxOutputTokens = 1024
+        config.speechSpeed = 1.25
+        config.transcriptionModel = "inworld/inworld-stt-1"
+        config.transcriptionLanguage = "en"
+        config.noiseReduction = "near_field"
+        config.turnDetection = .serverVAD(
+            threshold: 0.6,
+            prefixPaddingMs: 300,
+            silenceDurationMs: 700,
+            idleTimeoutMs: 5000
+        )
+        config.createResponse = false
+        config.interruptResponse = false
+
+        let json = try encodeToDictionary(SessionUpdateEvent(config: config))
+        let session = try XCTUnwrap(json["session"] as? [String: Any])
+        XCTAssertEqual(session["temperature"] as? Double, 0.9)
+        XCTAssertEqual(session["max_output_tokens"] as? Int, 1024)
+
+        let audio = try XCTUnwrap(session["audio"] as? [String: Any])
+        let input = try XCTUnwrap(audio["input"] as? [String: Any])
+
+        let transcription = try XCTUnwrap(input["transcription"] as? [String: Any])
+        XCTAssertEqual(transcription["model"] as? String, "inworld/inworld-stt-1")
+        XCTAssertEqual(transcription["language"] as? String, "en")
+
+        let noiseReduction = try XCTUnwrap(input["noise_reduction"] as? [String: Any])
+        XCTAssertEqual(noiseReduction["type"] as? String, "near_field")
+
+        let turnDetection = try XCTUnwrap(input["turn_detection"] as? [String: Any])
+        XCTAssertEqual(turnDetection["type"] as? String, "server_vad")
+        XCTAssertEqual(turnDetection["threshold"] as? Double, 0.6)
+        XCTAssertEqual(turnDetection["prefix_padding_ms"] as? Int, 300)
+        XCTAssertEqual(turnDetection["silence_duration_ms"] as? Int, 700)
+        XCTAssertEqual(turnDetection["idle_timeout_ms"] as? Int, 5000)
+        XCTAssertEqual(turnDetection["create_response"] as? Bool, false)
+        XCTAssertEqual(turnDetection["interrupt_response"] as? Bool, false)
+        XCTAssertNil(turnDetection["eagerness"])
+
+        let output = try XCTUnwrap(audio["output"] as? [String: Any])
+        XCTAssertEqual(output["speed"] as? Double, 1.25)
+    }
+
+    func testSettingsStoreSessionConfigOmitsDefaults() {
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        let settings = SettingsStore(defaults: defaults)
+        let config = settings.makeSessionConfig()
+
+        XCTAssertNil(config.temperature)
+        XCTAssertNil(config.maxOutputTokens)
+        XCTAssertNil(config.speechSpeed)
+        XCTAssertNil(config.transcriptionModel)
+        XCTAssertNil(config.transcriptionLanguage)
+        XCTAssertNil(config.noiseReduction)
+        if case .semanticVAD(let eagerness) = config.turnDetection {
+            XCTAssertEqual(eagerness, "high")
+        } else {
+            XCTFail("expected semantic VAD by default")
+        }
+    }
+
+    func testProviderDataOmittedByDefault() throws {
+        let json = try encodeToDictionary(SessionUpdateEvent(config: makeBaseConfig()))
+        let session = try XCTUnwrap(json["session"] as? [String: Any])
+        XCTAssertNil(session["providerData"])
+        XCTAssertNil(session["provider_data"])
+    }
+
+    func testProviderDataKeyIsCamelCaseWhileInnerKeysAreSnakeCase() throws {
+        var config = makeBaseConfig()
+        config.backchannel = SessionConfig.BackchannelConfig(
+            maxPerTurn: 3, minGapMs: 4000, minSpeechMs: 800, volumeGain: 0.6,
+            deciderKind: "llm", ruleFireProbability: 1.0
+        )
+        // Assert the raw JSON string, since the camelCase exception is the whole point.
+        let data = try ClientEventEncoder.encode(SessionUpdateEvent(config: config))
+        let raw = String(decoding: data, as: UTF8.self)
+        XCTAssertTrue(raw.contains("\"providerData\""), "providerData must stay camelCase")
+        XCTAssertFalse(raw.contains("\"provider_data\""), "must not be snake_cased")
+        XCTAssertTrue(raw.contains("\"max_per_turn\""), "inner keys stay snake_case")
+        XCTAssertTrue(raw.contains("\"output_modalities\""))
+    }
+
+    func testBackchannelAndResponsivenessEncoding() throws {
+        var config = makeBaseConfig()
+        config.backchannel = SessionConfig.BackchannelConfig(
+            maxPerTurn: 2, minGapMs: 3000, minSpeechMs: 600, volumeGain: 0.5,
+            deciderKind: "rule", ruleFireProbability: 0.25
+        )
+        config.responsiveness = SessionConfig.ResponsivenessConfig(
+            initialWaitTimeoutMs: 900, maxInitialPerTurn: 1, minFillerGapMs: 6000,
+            maxTokens: 10, enableOnFirstReply: true
+        )
+
+        let json = try encodeToDictionary(SessionUpdateEvent(config: config))
+        let session = try XCTUnwrap(json["session"] as? [String: Any])
+        let providerData = try XCTUnwrap(session["providerData"] as? [String: Any])
+
+        let backchannel = try XCTUnwrap(providerData["backchannel"] as? [String: Any])
+        XCTAssertEqual(backchannel["enabled"] as? Bool, true)
+        XCTAssertEqual(backchannel["max_per_turn"] as? Int, 2)
+        XCTAssertEqual(backchannel["min_gap_ms"] as? Int, 3000)
+        XCTAssertEqual(backchannel["min_speech_ms"] as? Int, 600)
+        XCTAssertEqual(backchannel["volume_gain"] as? Double, 0.5)
+        XCTAssertEqual(backchannel["decider_kind"] as? String, "rule")
+        XCTAssertEqual(backchannel["rule_fire_probability"] as? Double, 0.25)
+
+        let responsiveness = try XCTUnwrap(providerData["responsiveness"] as? [String: Any])
+        XCTAssertEqual(responsiveness["enabled"] as? Bool, true)
+        XCTAssertEqual(responsiveness["initial_wait_timeout_ms"] as? Int, 900)
+        XCTAssertEqual(responsiveness["max_initial_per_turn"] as? Int, 1)
+        XCTAssertEqual(responsiveness["min_filler_gap_ms"] as? Int, 6000)
+        XCTAssertEqual(responsiveness["max_tokens"] as? Int, 10)
+        XCTAssertEqual(responsiveness["enable_filler_on_first_assistant_reply"] as? Bool, true)
+    }
+
+    func testProviderDataOnlyBackchannel() throws {
+        var config = makeBaseConfig()
+        config.backchannel = SessionConfig.BackchannelConfig(
+            maxPerTurn: 3, minGapMs: 4000, minSpeechMs: 800, volumeGain: 0.6,
+            deciderKind: "llm", ruleFireProbability: 0.5
+        )
+        let json = try encodeToDictionary(SessionUpdateEvent(config: config))
+        let providerData = try XCTUnwrap((json["session"] as? [String: Any])?["providerData"] as? [String: Any])
+        let backchannel = try XCTUnwrap(providerData["backchannel"] as? [String: Any])
+        // rule_fire_probability is omitted for the llm decider.
+        XCTAssertNil(backchannel["rule_fire_probability"])
+        XCTAssertNil(providerData["responsiveness"])
+    }
+
+    func testConversationItemCreateShape() throws {
+        let json = try encodeToDictionary(ConversationItemCreateEvent(userText: "Say hello."))
+        XCTAssertEqual(json["type"] as? String, "conversation.item.create")
+        let item = try XCTUnwrap(json["item"] as? [String: Any])
+        XCTAssertEqual(item["type"] as? String, "message")
+        XCTAssertEqual(item["role"] as? String, "user")
+        let content = try XCTUnwrap(item["content"] as? [[String: Any]])
+        XCTAssertEqual(content.count, 1)
+        XCTAssertEqual(content[0]["type"] as? String, "input_text")
+        XCTAssertEqual(content[0]["text"] as? String, "Say hello.")
+    }
+
+    func testResponseCreateAndCancel() throws {
+        XCTAssertEqual(try encodeToDictionary(ResponseCreateEvent())["type"] as? String, "response.create")
+        XCTAssertEqual(try encodeToDictionary(ResponseCancelEvent())["type"] as? String, "response.cancel")
+    }
+}

--- a/realtime/ios/webrtc/Tests/ConversationViewModelTests.swift
+++ b/realtime/ios/webrtc/Tests/ConversationViewModelTests.swift
@@ -1,0 +1,131 @@
+import XCTest
+@testable import InworldVoiceAgent
+
+@MainActor
+final class ConversationViewModelTests: XCTestCase {
+    private func makeViewModel() -> ConversationViewModel {
+        ConversationViewModel(settings: SettingsStore(defaults: UserDefaults(suiteName: UUID().uuidString)!))
+    }
+
+    func testAgentDeltaStreamingAndFinalize() {
+        let vm = makeViewModel()
+        vm.handle(.outputTextDelta("Hel"))
+        vm.handle(.outputTextDelta("lo!"))
+        XCTAssertEqual(vm.transcript.count, 1)
+        XCTAssertEqual(vm.transcript[0].text, "Hello!")
+        XCTAssertTrue(vm.transcript[0].isStreaming)
+
+        vm.handle(.transcriptDone("Hello there!"))
+        XCTAssertEqual(vm.transcript[0].text, "Hello there!")
+        XCTAssertFalse(vm.transcript[0].isStreaming)
+    }
+
+    func testFinalizeWithNilKeepsAccumulatedText() {
+        let vm = makeViewModel()
+        vm.handle(.outputTextDelta("Hi"))
+        vm.handle(.responseDone)
+        XCTAssertEqual(vm.transcript[0].text, "Hi")
+        XCTAssertFalse(vm.transcript[0].isStreaming)
+    }
+
+    func testUserTranscriptAppends() {
+        let vm = makeViewModel()
+        vm.handle(.inputTranscriptionCompleted("What's up?"))
+        XCTAssertEqual(vm.transcript.count, 1)
+        XCTAssertEqual(vm.transcript[0].role, .user)
+        XCTAssertEqual(vm.transcript[0].text, "What's up?")
+    }
+
+    func testUserPartialTranscriptStreamsThenFinalizes() {
+        let vm = makeViewModel()
+        vm.handle(.inputTranscriptionDelta("what "))
+        vm.handle(.inputTranscriptionDelta("time"))
+        XCTAssertEqual(vm.transcript.count, 1)
+        XCTAssertEqual(vm.transcript[0].role, .user)
+        XCTAssertEqual(vm.transcript[0].text, "what time")
+        XCTAssertTrue(vm.transcript[0].isStreaming)
+
+        vm.handle(.inputTranscriptionCompleted("What time is it?"))
+        XCTAssertEqual(vm.transcript.count, 1)
+        XCTAssertEqual(vm.transcript[0].text, "What time is it?")
+        XCTAssertFalse(vm.transcript[0].isStreaming)
+    }
+
+    func testCumulativePartialsDoNotDuplicate() {
+        // Soniox-style: each partial is the full text so far.
+        let vm = makeViewModel()
+        vm.handle(.inputTranscriptionDelta("what"))
+        vm.handle(.inputTranscriptionDelta("what time"))
+        vm.handle(.inputTranscriptionDelta("what time is it"))
+        XCTAssertEqual(vm.transcript.count, 1)
+        XCTAssertEqual(vm.transcript[0].text, "what time is it")
+    }
+
+    func testReconcileTranscriptHandlesBothShapes() {
+        typealias VM = ConversationViewModel
+        // Cumulative
+        XCTAssertEqual(VM.reconcileTranscript(existing: "what", delta: "what time"), "what time")
+        // Duplicate cumulative re-send
+        XCTAssertEqual(VM.reconcileTranscript(existing: "what time", delta: "what time"), "what time")
+        // Stale shorter snapshot
+        XCTAssertEqual(VM.reconcileTranscript(existing: "what time", delta: "what"), "what time")
+        // Incremental chunk
+        XCTAssertEqual(VM.reconcileTranscript(existing: "what", delta: " time"), "what time")
+        // First chunk
+        XCTAssertEqual(VM.reconcileTranscript(existing: "", delta: "what"), "what")
+    }
+
+    func testSecondUserTurnStartsNewBubble() {
+        let vm = makeViewModel()
+        vm.handle(.inputTranscriptionDelta("hi"))
+        vm.handle(.inputTranscriptionCompleted("Hi."))
+        vm.handle(.inputTranscriptionDelta("bye"))
+        XCTAssertEqual(vm.transcript.count, 2)
+        XCTAssertEqual(vm.transcript[1].text, "bye")
+        XCTAssertTrue(vm.transcript[1].isStreaming)
+    }
+
+    func testEmptyFinalKeepsStreamedPartialText() {
+        let vm = makeViewModel()
+        vm.handle(.inputTranscriptionDelta("hello"))
+        vm.handle(.inputTranscriptionCompleted("  "))
+        XCTAssertEqual(vm.transcript.count, 1)
+        XCTAssertEqual(vm.transcript[0].text, "hello")
+        XCTAssertFalse(vm.transcript[0].isStreaming)
+    }
+
+    func testBargeInDropsStreamingAgentBubble() {
+        let vm = makeViewModel()
+        vm.handle(.outputTextDelta("I was saying"))
+        vm.handle(.speechStarted)
+        XCTAssertTrue(vm.transcript.isEmpty)
+
+        // New agent response after barge-in starts a fresh bubble
+        vm.handle(.outputTextDelta("Sure,"))
+        XCTAssertEqual(vm.transcript.count, 1)
+        XCTAssertEqual(vm.transcript[0].text, "Sure,")
+    }
+
+    func testBargeInKeepsFinalizedBubbles() {
+        let vm = makeViewModel()
+        vm.handle(.outputTextDelta("Done answer"))
+        vm.handle(.responseDone)
+        vm.handle(.speechStarted)
+        XCTAssertEqual(vm.transcript.count, 1)
+    }
+
+    func testNewResponseAfterFinalizeStartsNewBubble() {
+        let vm = makeViewModel()
+        vm.handle(.outputTextDelta("First"))
+        vm.handle(.responseDone)
+        vm.handle(.outputTextDelta("Second"))
+        XCTAssertEqual(vm.transcript.count, 2)
+        XCTAssertEqual(vm.transcript[1].text, "Second")
+    }
+
+    func testEmptyUserTranscriptIgnored() {
+        let vm = makeViewModel()
+        vm.handle(.inputTranscriptionCompleted("  \n"))
+        XCTAssertTrue(vm.transcript.isEmpty)
+    }
+}

--- a/realtime/ios/webrtc/Tests/ServerEventDecodingTests.swift
+++ b/realtime/ios/webrtc/Tests/ServerEventDecodingTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+@testable import InworldVoiceAgent
+
+final class ServerEventDecodingTests: XCTestCase {
+    private func decode(_ json: String) -> ServerEvent {
+        ServerEvent.decode(Data(json.utf8))
+    }
+
+    func testOutputTextDeltaVariants() {
+        for type in [
+            "response.output_text.delta",
+            "response.text.delta",
+            "response.audio_transcript.delta",
+            "response.output_audio_transcript.delta",
+        ] {
+            let event = decode(#"{"type": "\#(type)", "delta": "Hel"}"#)
+            XCTAssertEqual(event, .outputTextDelta("Hel"), "for type \(type)")
+        }
+    }
+
+    func testTranscriptDone() {
+        let event = decode(#"{"type": "response.output_audio_transcript.done", "transcript": "Hello there."}"#)
+        XCTAssertEqual(event, .transcriptDone("Hello there."))
+    }
+
+    func testContentPartDone() {
+        let event = decode(#"{"type": "response.content_part.done", "part": {"transcript": "Hi!"}}"#)
+        XCTAssertEqual(event, .transcriptDone("Hi!"))
+    }
+
+    func testContentPartDoneWithoutTranscript() {
+        let event = decode(#"{"type": "response.content_part.done", "part": {}}"#)
+        XCTAssertEqual(event, .transcriptDone(nil))
+    }
+
+    func testInputTranscriptionDelta() {
+        let event = decode(#"{"type": "conversation.item.input_audio_transcription.delta", "item_id": "i1", "delta": "what"}"#)
+        XCTAssertEqual(event, .inputTranscriptionDelta("what"))
+    }
+
+    func testInputTranscriptionCompleted() {
+        let event = decode(#"{"type": "conversation.item.input_audio_transcription.completed", "transcript": "What time is it?"}"#)
+        XCTAssertEqual(event, .inputTranscriptionCompleted("What time is it?"))
+    }
+
+    func testSpeechStarted() {
+        XCTAssertEqual(decode(#"{"type": "input_audio_buffer.speech_started"}"#), .speechStarted)
+    }
+
+    func testOutputItemAdded() {
+        XCTAssertEqual(decode(#"{"type": "response.output_item.added", "item": {}}"#), .outputItemAdded)
+    }
+
+    func testResponseDone() {
+        XCTAssertEqual(decode(#"{"type": "response.done", "response": {"status": "completed"}}"#), .responseDone)
+    }
+
+    func testBackchannelAudioDelta() {
+        let event = decode(#"{"type": "response.backchannel.audio.delta", "backchannel_id": "b1", "delta": "AAEC"}"#)
+        XCTAssertEqual(event, .backchannelAudioDelta(base64PCM16: "AAEC"))
+    }
+
+    func testBackchannelAudioDone() {
+        let event = decode(#"{"type": "response.backchannel.audio.done", "backchannel_id": "b1", "phrase": "uh-huh"}"#)
+        XCTAssertEqual(event, .backchannelAudioDone(phrase: "uh-huh"))
+    }
+
+    func testBackchannelSkipped() {
+        let event = decode(#"{"type": "response.backchannel.skipped", "backchannel_id": "b1", "reason": "deadline_missed"}"#)
+        XCTAssertEqual(event, .backchannelSkipped(reason: "deadline_missed"))
+    }
+
+    func testErrorEvent() {
+        let event = decode(#"{"type": "error", "error": {"message": "bad things"}}"#)
+        XCTAssertEqual(event, .error("bad things"))
+    }
+
+    func testUnknownTypeNeverThrows() {
+        XCTAssertEqual(decode(#"{"type": "response.output_audio.delta", "delta": "AAAA"}"#),
+                       .unknown(type: "response.output_audio.delta"))
+    }
+
+    func testGarbageInput() {
+        XCTAssertEqual(decode("not json"), .unknown(type: ""))
+    }
+}

--- a/realtime/ios/webrtc/project.yml
+++ b/realtime/ios/webrtc/project.yml
@@ -1,0 +1,46 @@
+name: InworldVoiceAgent
+options:
+  bundleIdPrefix: ai.inworld
+  deploymentTarget:
+    iOS: "17.0"
+packages:
+  WebRTC:
+    url: https://github.com/stasel/WebRTC
+    exactVersion: 148.0.0
+targets:
+  InworldVoiceAgent:
+    type: application
+    platform: iOS
+    sources:
+      - path: Sources
+        excludes: ["**/*.example"]
+    dependencies:
+      - package: WebRTC
+    info:
+      path: Sources/Info.plist
+      properties:
+        NSMicrophoneUsageDescription: "Microphone is used to talk to the voice agent."
+        UIBackgroundModes: [audio]
+        UILaunchScreen: {}
+        UISupportedInterfaceOrientations: [UIInterfaceOrientationPortrait]
+        UISupportedInterfaceOrientations~ipad:
+          - UIInterfaceOrientationPortrait
+          - UIInterfaceOrientationPortraitUpsideDown
+          - UIInterfaceOrientationLandscapeLeft
+          - UIInterfaceOrientationLandscapeRight
+    settings:
+      base:
+        SWIFT_VERSION: "5.10"
+        TARGETED_DEVICE_FAMILY: "1,2"
+        CODE_SIGN_STYLE: Automatic
+        INFOPLIST_KEY_CFBundleDisplayName: Inworld Voice
+  InworldVoiceAgentTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources: [Tests]
+    dependencies:
+      - target: InworldVoiceAgent
+    settings:
+      base:
+        SWIFT_VERSION: "5.10"
+        GENERATE_INFOPLIST_FILE: YES


### PR DESCRIPTION
## Summary
Adds `realtime/ios/webrtc` — a native SwiftUI iOS app for the Inworld Realtime API over WebRTC, mirroring the [`realtime/js/webrtc`](../tree/main/realtime/js/webrtc) example. It streams mic audio to the API, plays the agent's audio reply, and shows a live chat transcript of both sides.

Placed under `realtime/ios/` to sit alongside `realtime/python/` and `realtime/js/`; root README updated.

## What it does
- Full-duplex voice over a single `RTCPeerConnection` (Opus mic track + agent audio track), data channel `oai-events`.
- Same handshake as the JS example: `GET /v1/realtime/ice-servers` → offer SDP `POST /v1/realtime/calls` (`application/sdp`) → answer; on data-channel open sends `session.update` / greeting / `response.create`.
- Streaming chat transcript: agent text and partial user transcripts update live.
- Barge-in (mutes agent track + `response.cancel`), back-channel audio played out-of-band so it stays audible while the user speaks, and live model/voice pickers fetched from the Inworld models/voices APIs.
- **Both auth variants** via an in-app picker: Basic (API key, mirrors `js/webrtc/basic`) and Backend JWT (fetches `{ jwt, ice_servers, url }` from the `js/webrtc/jwt` Node server; no secrets in the app).

## Stack
- SwiftUI, iOS 17+; WebRTC via the [stasel/WebRTC](https://github.com/stasel/WebRTC) SPM xcframework; project generated with [XcodeGen](https://github.com/yonaskolb/XcodeGen) (`project.yml`).

## Secrets
- `Secrets.swift` is **gitignored**; `Secrets.swift.example` ships as an empty-key template. Setup mirrors the repo's `.env.example` convention: `cp Sources/App/Secrets.swift.example Sources/App/Secrets.swift`, or enter the key at runtime in Settings (Keychain). No real key is committed.

## Test plan
Setup:
```sh
brew install xcodegen
cp Sources/App/Secrets.swift.example Sources/App/Secrets.swift
xcodegen generate
```
- [x] `xcodebuild build ... -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO` — builds for the simulator from the new location
- [x] `xcodebuild test ... -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` — **43 unit tests pass** (event codec, transcript/barge-in state, catalog decoding, PCM conversion)
- [x] Physical device: real mic, echo cancellation during barge-in, speaker/Bluetooth routing, background audio (simulator can't validate these)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
