### PR TITLE
Remove contextCreated wait from low-latency WebSocket examples

### DIFF
--- a/tts/js/example_tts_low_latency_ws.js
+++ b/tts/js/example_tts_low_latency_ws.js
@@ -3,10 +3,12 @@
  * Example script for low-latency TTS synthesis using WebSocket.
  *
  * This script demonstrates how to achieve the lowest possible time-to-first-byte (TTFB)
- * with WebSocket by pre-establishing the connection and audio context before timing.
+ * with WebSocket by pre-establishing the connection and pipelining messages.
  *
- * Key technique: Connect and create the audio context ahead of time, then measure
- * only from text submission to first audio chunk arrival.
+ * Key technique: Send the context create message and text back-to-back without
+ * waiting for the contextCreated acknowledgment. The server processes messages
+ * in order, so waiting for the ack only adds a network round trip. TTFB is
+ * measured from the create message to first audio chunk arrival.
  */
 
 const WebSocket = require('ws');
@@ -49,11 +51,11 @@ function splitSentences(text) {
 }
 
 /**
- * Measure low-latency TTS using WebSocket with pre-established context.
+ * Measure low-latency TTS using WebSocket with pipelined messages.
  *
- * Connects and creates the audio context before starting the timer,
- * then sends text sentence-by-sentence with flush_context on each
- * for lowest time-to-first-byte.
+ * Sends context create and text back-to-back without waiting for the
+ * contextCreated acknowledgment, sending text sentence-by-sentence with
+ * flush_context on each for lowest time-to-first-byte.
  *
  * @param {string} apiKey - API key for authentication
  * @param {string} text - Text to synthesize
@@ -68,7 +70,6 @@ async function websocketTts(apiKey, text, voiceId, modelId) {
 
     return new Promise((resolve) => {
         const ws = new WebSocket(url, { headers });
-        let contextReady = false;
         let startTime = null;
         let ttfb = null;
         let totalAudioBytes = 0;
@@ -88,7 +89,12 @@ async function websocketTts(apiKey, text, voiceId, modelId) {
         });
 
         ws.on('open', () => {
-            // Create context (not timed - this is setup)
+            // Send create, text, and close back-to-back without waiting for
+            // the contextCreated acknowledgment. Messages are processed in
+            // order on the server, so waiting for the ack only adds a full
+            // network round trip before the first audio chunk.
+            startTime = Date.now();
+
             ws.send(JSON.stringify({
                 context_id: contextId,
                 create: {
@@ -100,6 +106,22 @@ async function websocketTts(apiKey, text, voiceId, modelId) {
                         bit_rate: 32000
                     }
                 }
+            }));
+
+            // Send text sentence-by-sentence, flushing each for lowest TTFB
+            const sentences = splitSentences(text);
+            for (const sentence of sentences) {
+                ws.send(JSON.stringify({
+                    context_id: contextId,
+                    send_text: {
+                        text: sentence,
+                        flush_context: {}
+                    }
+                }));
+            }
+            ws.send(JSON.stringify({
+                context_id: contextId,
+                close_context: {}
             }));
         });
 
@@ -114,33 +136,6 @@ async function websocketTts(apiKey, text, voiceId, modelId) {
                 }
 
                 const result = data.result;
-
-                // Wait for context creation confirmation
-                if (!contextReady) {
-                    if (result && result.contextCreated !== undefined) {
-                        contextReady = true;
-
-                        // Start timer - context ready, measure synthesis only
-                        startTime = Date.now();
-
-                        // Send text sentence-by-sentence, flushing each for lowest TTFB
-                        const sentences = splitSentences(text);
-                        for (const sentence of sentences) {
-                            ws.send(JSON.stringify({
-                                context_id: contextId,
-                                send_text: {
-                                    text: sentence,
-                                    flush_context: {}
-                                }
-                            }));
-                        }
-                        ws.send(JSON.stringify({
-                            context_id: contextId,
-                            close_context: {}
-                        }));
-                    }
-                    return;
-                }
 
                 if (!result) {
                     if (data.done) {
@@ -201,7 +196,7 @@ async function main() {
     console.log(`   Text: "${text}"`);
     console.log(`  Voice: ${voiceId}`);
     console.log(`  Model: ${modelId}`);
-    console.log('\nConnecting and creating context, then generating audio...\n');
+    console.log('\nConnecting, then generating audio...\n');
 
     try {
         const result = await websocketTts(apiKey, text, voiceId, modelId);

--- a/tts/python/example_tts_low_latency_ws.py
+++ b/tts/python/example_tts_low_latency_ws.py
@@ -3,10 +3,12 @@
 Example script for low-latency TTS synthesis using WebSocket.
 
 This script demonstrates how to achieve the lowest possible time-to-first-byte (TTFB)
-with WebSocket by pre-establishing the connection and audio context before timing.
+with WebSocket by pre-establishing the connection and pipelining messages.
 
-Key technique: Connect and create the audio context ahead of time, then measure
-only from text submission to first audio chunk arrival.
+Key technique: Send the context create message and text back-to-back without
+waiting for the contextCreated acknowledgment. The server processes messages
+in order, so waiting for the ack only adds a network round trip. TTFB is
+measured from the create message to first audio chunk arrival.
 """
 
 import asyncio
@@ -50,9 +52,10 @@ def check_api_key():
 
 async def websocket_tts(api_key, text, voice_id, model_id, auto_mode):
     """
-    Measure low-latency TTS using WebSocket with pre-established context.
-    Connects and creates the audio context before starting the timer,
-    then measures TTFB from text submission to first audio chunk.
+    Measure low-latency TTS using WebSocket with pipelined messages.
+    Sends context create and text back-to-back without waiting for the
+    contextCreated acknowledgment, measuring TTFB from the create message
+    to the first audio chunk.
     Args:
         api_key: API key for authentication
         text: Text to synthesize
@@ -71,7 +74,12 @@ async def websocket_tts(api_key, text, voice_id, model_id, auto_mode):
 
     try:
         async with websockets.connect(url, additional_headers=headers) as ws:
-            # Create context (not timed - this is setup)
+            # Send create, text, and close back-to-back without waiting for
+            # the contextCreated acknowledgment. Messages are processed in
+            # order on the server, so waiting for the ack only adds a full
+            # network round trip before the first audio chunk.
+            start_time = time.time()
+
             create_payload = {
                 "voice_id": voice_id,
                 "model_id": model_id,
@@ -85,20 +93,6 @@ async def websocket_tts(api_key, text, voice_id, model_id, auto_mode):
                 create_payload["autoMode"] = True
             create_msg = {"context_id": context_id, "create": create_payload}
             await ws.send(json.dumps(create_msg))
-
-            # Wait for context creation confirmation
-            while True:
-                msg = await ws.recv()
-                data = json.loads(msg)
-                if "error" in data:
-                    print(f"WebSocket error: {data['error']}")
-                    return None
-                result = data.get("result", {})
-                if "contextCreated" in result:
-                    break
-
-            # Start timer - context is ready, measure synthesis latency only
-            start_time = time.time()
 
             sentences = split_sentences(text)
             for sentence in sentences:
@@ -181,7 +175,7 @@ async def main():
     print(f"  Model: {model_id}")
     if auto_mode:
         print(f"   Auto: enabled")
-    print(f"\nConnecting and creating context, then generating audio...\n")
+    print(f"\nConnecting, then generating audio...\n")
 
     try:
         result = await websocket_tts(api_key, text, voice_id, model_id, auto_mode=auto_mode)

--- a/tts/python/example_tts_low_latency_ws.py
+++ b/tts/python/example_tts_low_latency_ws.py
@@ -116,7 +116,7 @@ async def websocket_tts(api_key, text, voice_id, model_id, auto_mode):
 
                 if "error" in data:
                     print(f"WebSocket error: {data['error']}")
-                    break
+                    return None
 
                 result = data.get("result")
                 if not result:


### PR DESCRIPTION
## Summary

The bidirectional streaming WebSocket API processes messages in order per connection. Text can therefore be sent immediately after the context create message — waiting for the `contextCreated` acknowledgment adds a full network round trip before the first audio chunk with no benefit.

This change updates both low-latency WebSocket examples (Python and JavaScript) to:

- Send `create`, `send_text`, and `close_context` messages back-to-back without waiting for the acknowledgment.
- Measure TTFB from the create message, reflecting actual user-perceived latency.

## Impact

Measured against production, pipelining reduces end-to-end time to first audio by roughly one network round trip (~30% for typical clients).

## Testing

Both examples run against production and produce audio with the expected latency improvement.