### PR TITLE
feat(realtime/flutter): cross-platform WebRTC voice-agent example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ inworld-api-examples/
 └── realtime/
     ├── python/
     ├── js/
-    └── ios/
+    ├── ios/
+    ├── android/
+    └── flutter/
 ```
 
 ## Getting Started
@@ -62,3 +64,5 @@ Covers WebSocket and WebRTC-based real-time voice agents with both basic and JWT
 - **[Python](./realtime/python/)** — Real-time voice agent examples in Python
 - **[JavaScript](./realtime/js/)** — Real-time voice agent examples in JavaScript
 - **[iOS](./realtime/ios/)** — Native SwiftUI WebRTC voice-agent app
+- **[Android](./realtime/android/)** — Native Jetpack Compose WebRTC voice-agent app
+- **[Flutter](./realtime/flutter/)** — Cross-platform (iOS + Android) WebRTC voice-agent app

--- a/realtime/README.md
+++ b/realtime/README.md
@@ -4,5 +4,8 @@
 |---|---|
 | [`python/`](python/) | Realtime voice agent examples in Python (WebSocket proxy, WebRTC) with Basic and JWT auth |
 | [`js/`](js/) | Realtime voice agent examples in JavaScript/Node.js (WebSocket proxy, WebRTC) with Basic and JWT auth |
+| [`ios/`](ios/) | Native SwiftUI WebRTC voice-agent app (Basic and JWT auth) |
+| [`android/`](android/) | Native Jetpack Compose WebRTC voice-agent app (Basic and JWT auth) |
+| [`flutter/`](flutter/) | Cross-platform (iOS + Android) WebRTC voice-agent app (Basic and JWT auth) |
 
 See each subdirectory's README for setup and usage.

--- a/realtime/flutter/webrtc/.gitignore
+++ b/realtime/flutter/webrtc/.gitignore
@@ -1,0 +1,25 @@
+# Dart / Flutter
+.dart_tool/
+.packages
+build/
+.flutter-plugins
+.flutter-plugins-dependencies
+pubspec.lock
+
+# Generated platform runners (run `flutter create .` to populate).
+/android/
+/ios/
+/linux/
+/macos/
+/windows/
+/web/
+
+# The repo-root .gitignore is Python-oriented and ignores `lib/`; re-include the
+# Flutter source directory, then re-exclude the gitignored secrets file.
+!lib/
+!lib/**
+lib/secrets.dart
+
+# Secrets — never commit a real key.
+
+.DS_Store

--- a/realtime/flutter/webrtc/README.md
+++ b/realtime/flutter/webrtc/README.md
@@ -1,0 +1,104 @@
+# Inworld Realtime — Flutter (WebRTC)
+
+A cross-platform (iOS + Android) voice-agent app for the Inworld Realtime API over
+WebRTC: it streams mic audio to the API, plays the agent's audio reply, and shows a
+live chat transcript of both sides. It mirrors the [JS WebRTC example](../../js/webrtc)
+and the native [iOS](../../ios/webrtc) and [Android](../../android/webrtc) examples, and
+supports both auth variants (`basic` and `jwt`) via an in-app picker.
+
+- Flutter 3.24+, Dart 3.5+
+- WebRTC via [`flutter_webrtc`](https://pub.dev/packages/flutter_webrtc)
+- One Dart codebase for both platforms
+
+## Scope
+
+This is a **cross-platform quickstart**. It ports the full realtime protocol, the
+streaming transcript, barge-in, settings, and back-channel playback. It intentionally
+does **not** port the native examples' audio-engineering debug section (audio-session
+mode toggles, hardware-AEC switch), which lives below Flutter and requires per-platform
+native code — use the [iOS](../../ios/webrtc) / [Android](../../android/webrtc) examples
+as the reference for echo/AEC tuning. A couple of other simplifications versus the
+native apps:
+
+- Model/voice are free-text fields here; the native apps fetch live pickers from the
+  catalog APIs.
+- Back-channel PCM chunks are buffered per interjection and played as a WAV clip (Flutter
+  has no stock streaming-PCM sink); the native apps stream each chunk into a live node.
+
+## Setup
+
+```sh
+cp lib/secrets.dart.example lib/secrets.dart
+# Generate the platform runner projects (android/, ios/, …) into this directory:
+flutter create .
+flutter pub get
+```
+
+`flutter create .` scaffolds the native runner projects that Flutter needs to build but
+that aren't checked in (they're gitignored). After running it once, apply the two
+permission edits below, then `flutter run`.
+
+`lib/secrets.dart` is gitignored. Either paste your base64 `INWORLD_API_KEY` into it
+(used as the default), or leave it empty and enter the key at runtime in the app's
+Settings (gear icon) — it's stored in SharedPreferences. Never commit a real key.
+
+### Required permission edits (after `flutter create .`)
+
+**iOS** — add to `ios/Runner/Info.plist`:
+
+```xml
+<key>NSMicrophoneUsageDescription</key>
+<string>Voice conversations with the Inworld agent.</string>
+```
+
+**Android** — add to `android/app/src/main/AndroidManifest.xml` (inside `<manifest>`,
+above `<application>`):
+
+```xml
+<uses-permission android:name="android.permission.INTERNET"/>
+<uses-permission android:name="android.permission.RECORD_AUDIO"/>
+<uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
+```
+
+`flutter_webrtc` needs Android `minSdkVersion 23` — set it in
+`android/app/build.gradle` if `flutter create` used a lower default.
+
+### Auth modes
+
+- **API Key (Basic)** — the key is sent as `Authorization: Basic <key>` directly to
+  `api.inworld.ai`. Simplest; fine for development. Mirrors `js/webrtc/basic`.
+- **Backend JWT** — the app fetches `{ jwt, ice_servers, url }` from `<backend>/api/config`,
+  i.e. the [`js/webrtc/jwt`](../../js/webrtc/jwt) Node server. No Inworld secrets ship
+  in the app.
+
+## How it works
+
+1. `GET /v1/realtime/ice-servers` → ICE config.
+2. `RTCPeerConnection` (unified plan) + data channel `oai-events` + mic audio track.
+3. Offer SDP → `POST /v1/realtime/calls` (`Content-Type: application/sdp`) → answer SDP.
+4. On data-channel open: `session.update` (model, instructions, semantic VAD,
+   `inworld-tts-2` voice, optional web search / back-channel / responsiveness), greeting
+   `conversation.item.create`, `response.create`.
+5. Agent audio arrives as a remote WebRTC track (auto-plays); transcripts stream over
+   the data channel. On `input_audio_buffer.speech_started` the app mutes the agent
+   track, sends `response.cancel`, and drops the in-flight bubble (barge-in).
+
+### The JSON casing contract
+
+The realtime session schema is snake_case everywhere **except** the single key
+`providerData`, which the Go server unmarshals as camelCase. A blanket snake_case
+strategy would emit `provider_data`, which the server silently ignores — so back-channel,
+responsiveness, and web search would never turn on. `lib/realtime/events/client_events.dart`
+builds the JSON by hand so that one key stays camelCase while its inner keys are
+snake_case; `test/client_event_encoding_test.dart` asserts this byte-for-byte.
+
+## Test from CLI
+
+```sh
+flutter test
+flutter analyze
+```
+
+The unit tests (event encoding/decoding, transcript reconciliation) are pure Dart and
+need no device. An end-to-end voice test needs a real device or simulator with a mic and
+your `INWORLD_API_KEY`.

--- a/realtime/flutter/webrtc/analysis_options.yaml
+++ b/realtime/flutter/webrtc/analysis_options.yaml
@@ -1,0 +1,6 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    prefer_single_quotes: true
+    require_trailing_commas: true

--- a/realtime/flutter/webrtc/lib/audio/backchannel_player.dart
+++ b/realtime/flutter/webrtc/lib/audio/backchannel_player.dart
@@ -1,0 +1,71 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:audioplayers/audioplayers.dart';
+
+/// Plays back-channel interjections, which arrive as base64 PCM16 chunks on the
+/// data channel (separate from the WebRTC remote track) so they stay audible while
+/// the user speaks.
+///
+/// The native examples stream each chunk into a live audio node. Flutter has no
+/// stock streaming-PCM sink, so we take the portable route: buffer the chunks for
+/// one interjection, then on `.done` wrap them in a WAV container and play the clip.
+/// Back-channels are short ("uh-huh"), so the buffer-then-play latency is negligible.
+class BackchannelPlayer {
+  static const int _sampleRate = 24000; // realtime output default: 24 kHz mono PCM16
+
+  final AudioPlayer _player = AudioPlayer(playerId: 'backchannel');
+  final BytesBuilder _buffer = BytesBuilder(copy: false);
+
+  void enqueue(String base64Pcm16) {
+    if (base64Pcm16.isEmpty) return;
+    _buffer.add(base64Decode(base64Pcm16));
+  }
+
+  Future<void> flush() async {
+    if (_buffer.isEmpty) return;
+    final pcm = _buffer.takeBytes();
+    await _player.play(BytesSource(_wrapWav(pcm), mimeType: 'audio/wav'));
+  }
+
+  Future<void> stop() async {
+    _buffer.clear();
+    await _player.stop();
+  }
+
+  Future<void> dispose() async {
+    await _player.dispose();
+  }
+
+  static Uint8List _wrapWav(Uint8List pcm) {
+    const channels = 1;
+    const bitsPerSample = 16;
+    const byteRate = _sampleRate * channels * bitsPerSample ~/ 8;
+    const blockAlign = channels * bitsPerSample ~/ 8;
+
+    final header = BytesBuilder();
+    void writeStr(String s) => header.add(ascii.encode(s));
+    void writeU32(int v) => header.add(
+          Uint8List(4)..buffer.asByteData().setUint32(0, v, Endian.little),
+        );
+    void writeU16(int v) => header.add(
+          Uint8List(2)..buffer.asByteData().setUint16(0, v, Endian.little),
+        );
+
+    writeStr('RIFF');
+    writeU32(36 + pcm.length);
+    writeStr('WAVE');
+    writeStr('fmt ');
+    writeU32(16);
+    writeU16(1); // PCM
+    writeU16(channels);
+    writeU32(_sampleRate);
+    writeU32(byteRate);
+    writeU16(blockAlign);
+    writeU16(bitsPerSample);
+    writeStr('data');
+    writeU32(pcm.length);
+    header.add(pcm);
+    return header.toBytes();
+  }
+}

--- a/realtime/flutter/webrtc/lib/auth/auth_provider.dart
+++ b/realtime/flutter/webrtc/lib/auth/auth_provider.dart
@@ -1,0 +1,103 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+class IceServer {
+  IceServer({required this.urls, this.username, this.credential});
+
+  final List<String> urls;
+  final String? username;
+  final String? credential;
+
+  /// `urls` may arrive as a single string or an array of strings.
+  factory IceServer.fromJson(Map<String, dynamic> json) {
+    final rawUrls = json['urls'];
+    return IceServer(
+      urls: rawUrls is String
+          ? [rawUrls]
+          : (rawUrls as List).map((e) => e as String).toList(),
+      username: json['username'] as String?,
+      credential: json['credential'] as String?,
+    );
+  }
+}
+
+class RealtimeCredentials {
+  RealtimeCredentials({
+    required this.authorizationHeader,
+    this.apiBaseUrl = 'https://api.inworld.ai',
+    this.callsUrl,
+    this.preFetchedIceServers,
+  });
+
+  final String authorizationHeader;
+  final String apiBaseUrl;
+  final String? callsUrl;
+  final List<IceServer>? preFetchedIceServers;
+}
+
+class AuthException implements Exception {
+  AuthException(this.message);
+  final String message;
+  @override
+  String toString() => message;
+}
+
+abstract class AuthProvider {
+  Future<RealtimeCredentials> credentials();
+}
+
+class BasicAuthProvider implements AuthProvider {
+  BasicAuthProvider(this.apiKey);
+  final String apiKey;
+
+  @override
+  Future<RealtimeCredentials> credentials() async {
+    final key = apiKey.trim();
+    if (key.isEmpty) {
+      throw AuthException('Inworld API key is not set. Add it in Settings.');
+    }
+    return RealtimeCredentials(authorizationHeader: 'Basic $key');
+  }
+}
+
+/// Fetches a short-lived JWT from a trusted backend (the JS example's `webrtc/jwt`
+/// Node server) so no Inworld key/secret ships in the app.
+class BackendJwtAuthProvider implements AuthProvider {
+  BackendJwtAuthProvider(this.backendUrl, {http.Client? client})
+      : _client = client ?? http.Client();
+
+  final String backendUrl;
+  final http.Client _client;
+
+  @override
+  Future<RealtimeCredentials> credentials() async {
+    final base = Uri.tryParse(backendUrl);
+    if (base == null) throw AuthException('Backend URL is invalid.');
+
+    final response = await _client.get(base.resolve('api/config'));
+    if (response.statusCode != 200) {
+      throw AuthException('Backend config request failed: HTTP ${response.statusCode}');
+    }
+
+    final Map<String, dynamic> config;
+    try {
+      config = jsonDecode(response.body) as Map<String, dynamic>;
+    } catch (_) {
+      throw AuthException('Backend returned an invalid config payload.');
+    }
+
+    final iceServers = (config['ice_servers'] as List?)
+        ?.map((e) => IceServer.fromJson(e as Map<String, dynamic>))
+        .toList();
+    final callsUrl = (config['url'] as String?)?.isNotEmpty == true
+        ? config['url'] as String
+        : null;
+
+    return RealtimeCredentials(
+      authorizationHeader: 'Bearer ${config['jwt']}',
+      callsUrl: callsUrl,
+      preFetchedIceServers: iceServers,
+    );
+  }
+}

--- a/realtime/flutter/webrtc/lib/main.dart
+++ b/realtime/flutter/webrtc/lib/main.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'state/conversation_controller.dart';
+import 'storage/settings.dart';
+import 'ui/conversation_screen.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  final settings = await SettingsStore.load();
+  runApp(InworldVoiceAgentApp(settings: settings));
+}
+
+class InworldVoiceAgentApp extends StatelessWidget {
+  const InworldVoiceAgentApp({super.key, required this.settings});
+
+  final SettingsStore settings;
+
+  @override
+  Widget build(BuildContext context) {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider.value(value: settings),
+        ChangeNotifierProvider(create: (_) => ConversationController(settings)),
+      ],
+      child: MaterialApp(
+        title: 'Inworld Voice Agent',
+        theme: ThemeData(
+          colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF6C5CE7)),
+          useMaterial3: true,
+        ),
+        darkTheme: ThemeData(
+          colorScheme: ColorScheme.fromSeed(
+            seedColor: const Color(0xFF6C5CE7),
+            brightness: Brightness.dark,
+          ),
+          useMaterial3: true,
+        ),
+        home: const ConversationScreen(),
+      ),
+    );
+  }
+}

--- a/realtime/flutter/webrtc/lib/realtime/events/client_events.dart
+++ b/realtime/flutter/webrtc/lib/realtime/events/client_events.dart
@@ -1,0 +1,116 @@
+import '../session_config.dart';
+
+/// Client → server events, serialized to the realtime session schema.
+///
+/// The schema is snake_case everywhere EXCEPT the single key `providerData`, which
+/// the Go server unmarshals as camelCase (`json:"providerData"`). A blanket
+/// snake_case strategy would emit `provider_data`, which the server silently ignores
+/// — so back-channel, responsiveness, and web search never turn on. We build the JSON
+/// maps by hand so that one key stays camelCase while its inner keys are snake_case.
+///
+/// Null-valued fields are omitted (via the `putIfNotNull` helper) to match the
+/// native examples' `explicitNulls = false` behavior.
+extension _OmitNull on Map<String, dynamic> {
+  void putIfNotNull(String key, Object? value) {
+    if (value != null) this[key] = value;
+  }
+}
+
+Map<String, dynamic> sessionUpdateEvent(SessionConfig config) {
+  final turnDetection = <String, dynamic>{
+    'type': 'semantic_vad',
+    'eagerness': config.eagerness,
+    'create_response': config.createResponse,
+    'interrupt_response': config.interruptResponse,
+  };
+
+  final input = <String, dynamic>{'turn_detection': turnDetection};
+  if (config.transcriptionModel != null || config.transcriptionLanguage != null) {
+    input['transcription'] = <String, dynamic>{}
+      ..putIfNotNull('model', config.transcriptionModel)
+      ..putIfNotNull('language', config.transcriptionLanguage);
+  }
+  if (config.noiseReduction != null) {
+    input['noise_reduction'] = {'type': config.noiseReduction};
+  }
+
+  final output = <String, dynamic>{
+    'model': config.ttsModel,
+    'voice': config.voice,
+  }..putIfNotNull('speed', config.speechSpeed);
+
+  final session = <String, dynamic>{
+    'type': 'realtime',
+    'model': config.model,
+    'instructions': config.instructions,
+    'output_modalities': ['audio', 'text'],
+    'audio': {'input': input, 'output': output},
+  }
+    ..putIfNotNull('temperature', config.temperature)
+    ..putIfNotNull('max_output_tokens', config.maxOutputTokens);
+
+  final webSearch = config.webSearch;
+  if (webSearch != null) {
+    session['tools'] = [
+      {
+        'type': 'web_search',
+        // Literal camelCase key — see the class doc above.
+        'providerData': <String, dynamic>{'engine': webSearch.engine}
+          ..putIfNotNull('max_results', webSearch.maxResults)
+          ..putIfNotNull('max_steps', webSearch.maxSteps),
+      },
+    ];
+  }
+
+  final providerData = _providerData(config);
+  if (providerData != null) session['providerData'] = providerData;
+
+  return {'type': 'session.update', 'session': session};
+}
+
+Map<String, dynamic>? _providerData(SessionConfig config) {
+  final bc = config.backchannel;
+  final resp = config.responsiveness;
+  if (bc == null && resp == null) return null;
+
+  final providerData = <String, dynamic>{};
+  if (bc != null) {
+    providerData['backchannel'] = <String, dynamic>{
+      'enabled': true,
+      'max_per_turn': bc.maxPerTurn,
+      'min_gap_ms': bc.minGapMs,
+      'min_speech_ms': bc.minSpeechMs,
+      'volume_gain': bc.volumeGain,
+      'decider_kind': bc.deciderKind,
+    }..putIfNotNull(
+        'rule_fire_probability',
+        bc.deciderKind == 'rule' ? bc.ruleFireProbability : null,
+      );
+  }
+  if (resp != null) {
+    providerData['responsiveness'] = {
+      'enabled': true,
+      'initial_wait_timeout_ms': resp.initialWaitTimeoutMs,
+      'max_initial_per_turn': resp.maxInitialPerTurn,
+      'min_filler_gap_ms': resp.minFillerGapMs,
+      'max_tokens': resp.maxTokens,
+      'enable_filler_on_first_assistant_reply': resp.enableOnFirstReply,
+    };
+  }
+  return providerData;
+}
+
+Map<String, dynamic> conversationItemCreateEvent(String userText) => {
+      'type': 'conversation.item.create',
+      'item': {
+        'type': 'message',
+        'role': 'user',
+        'content': [
+          {'type': 'input_text', 'text': userText},
+        ],
+      },
+    };
+
+Map<String, dynamic> responseCreateEvent() => {'type': 'response.create'};
+
+Map<String, dynamic> responseCancelEvent() => {'type': 'response.cancel'};

--- a/realtime/flutter/webrtc/lib/realtime/events/server_event.dart
+++ b/realtime/flutter/webrtc/lib/realtime/events/server_event.dart
@@ -1,0 +1,112 @@
+import 'dart:convert';
+
+/// Server → client events. A sealed hierarchy mirroring the native examples'
+/// switch over the realtime event `type`.
+sealed class ServerEvent {
+  const ServerEvent();
+
+  static ServerEvent decode(String raw) {
+    final Map<String, dynamic> obj;
+    try {
+      obj = jsonDecode(raw) as Map<String, dynamic>;
+    } catch (_) {
+      return const UnknownEvent('');
+    }
+    final type = obj['type'] as String?;
+    if (type == null) return const UnknownEvent('');
+
+    switch (type) {
+      case 'response.output_text.delta':
+      case 'response.text.delta':
+      case 'response.audio_transcript.delta':
+      case 'response.output_audio_transcript.delta':
+        return OutputTextDelta(obj['delta'] as String? ?? '');
+      case 'response.output_audio_transcript.done':
+        return TranscriptDone(obj['transcript'] as String?);
+      case 'response.content_part.done':
+        final part = obj['part'] as Map<String, dynamic>?;
+        return TranscriptDone(part?['transcript'] as String?);
+      case 'conversation.item.input_audio_transcription.delta':
+        return InputTranscriptionDelta(obj['delta'] as String? ?? '');
+      case 'conversation.item.input_audio_transcription.completed':
+        return InputTranscriptionCompleted(obj['transcript'] as String? ?? '');
+      case 'input_audio_buffer.speech_started':
+        return const SpeechStarted();
+      case 'response.output_item.added':
+        return const OutputItemAdded();
+      case 'response.done':
+        return const ResponseDone();
+      case 'response.backchannel.audio.delta':
+        return BackchannelAudioDelta(obj['delta'] as String? ?? '');
+      case 'response.backchannel.audio.done':
+        return BackchannelAudioDone(obj['phrase'] as String?);
+      case 'response.backchannel.skipped':
+        return BackchannelSkipped(obj['reason'] as String? ?? '');
+      case 'error':
+        final error = obj['error'] as Map<String, dynamic>?;
+        final message = error?['message'] as String? ??
+            obj['message'] as String? ??
+            'unknown error';
+        return ErrorEvent(message);
+      default:
+        return UnknownEvent(type);
+    }
+  }
+}
+
+class OutputTextDelta extends ServerEvent {
+  const OutputTextDelta(this.delta);
+  final String delta;
+}
+
+class TranscriptDone extends ServerEvent {
+  const TranscriptDone(this.text);
+  final String? text;
+}
+
+class InputTranscriptionDelta extends ServerEvent {
+  const InputTranscriptionDelta(this.delta);
+  final String delta;
+}
+
+class InputTranscriptionCompleted extends ServerEvent {
+  const InputTranscriptionCompleted(this.transcript);
+  final String transcript;
+}
+
+class SpeechStarted extends ServerEvent {
+  const SpeechStarted();
+}
+
+class OutputItemAdded extends ServerEvent {
+  const OutputItemAdded();
+}
+
+class ResponseDone extends ServerEvent {
+  const ResponseDone();
+}
+
+class BackchannelAudioDelta extends ServerEvent {
+  const BackchannelAudioDelta(this.base64Pcm16);
+  final String base64Pcm16;
+}
+
+class BackchannelAudioDone extends ServerEvent {
+  const BackchannelAudioDone(this.phrase);
+  final String? phrase;
+}
+
+class BackchannelSkipped extends ServerEvent {
+  const BackchannelSkipped(this.reason);
+  final String reason;
+}
+
+class ErrorEvent extends ServerEvent {
+  const ErrorEvent(this.message);
+  final String message;
+}
+
+class UnknownEvent extends ServerEvent {
+  const UnknownEvent(this.type);
+  final String type;
+}

--- a/realtime/flutter/webrtc/lib/realtime/realtime_session.dart
+++ b/realtime/flutter/webrtc/lib/realtime/realtime_session.dart
@@ -1,0 +1,137 @@
+import 'package:flutter_webrtc/flutter_webrtc.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+import '../audio/backchannel_player.dart';
+import '../auth/auth_provider.dart';
+import '../webrtc/webrtc_client.dart';
+import 'events/client_events.dart';
+import 'events/server_event.dart';
+import 'session_config.dart';
+import 'signaling_api.dart';
+
+enum SessionStatus { idle, connecting, connected, failed }
+
+class SessionState {
+  const SessionState(this.status, [this.message]);
+  final SessionStatus status;
+  final String? message;
+
+  static const idle = SessionState(SessionStatus.idle);
+  static const connecting = SessionState(SessionStatus.connecting);
+  static const connected = SessionState(SessionStatus.connected);
+}
+
+class RealtimeSession {
+  RealtimeSession({required this.authProvider, required this.config});
+
+  final AuthProvider authProvider;
+  final SessionConfig config;
+
+  final BackchannelPlayer _backchannelPlayer = BackchannelPlayer();
+  WebRtcClient? _client;
+  bool _interrupted = false;
+
+  SessionState _state = SessionState.idle;
+  SessionState get state => _state;
+
+  void Function(SessionState state)? onStateChange;
+  void Function(ServerEvent event)? onEvent;
+
+  void _setState(SessionState next) {
+    _state = next;
+    onStateChange?.call(next);
+  }
+
+  Future<void> connect() async {
+    if (_state.status != SessionStatus.idle &&
+        _state.status != SessionStatus.failed) {
+      return;
+    }
+    _setState(SessionState.connecting);
+    try {
+      final mic = await Permission.microphone.request();
+      if (!mic.isGranted) {
+        _setState(const SessionState(
+          SessionStatus.failed,
+          'Microphone access denied. Enable it in system Settings.',
+        ));
+        return;
+      }
+
+      final credentials = await authProvider.credentials();
+      final api = SignalingApi(credentials);
+      final iceServers = await api.fetchIceServers();
+
+      final client = await WebRtcClient.create(iceServers);
+      _client = client;
+      _wireCallbacks(client);
+
+      final offer = await client.makeOfferSdp();
+      final answer = await api.postOffer(offer);
+      await client.setAnswer(answer);
+    } catch (error) {
+      await disconnect(failure: error.toString());
+    }
+  }
+
+  Future<void> disconnect({String? failure}) async {
+    await _client?.close();
+    _client = null;
+    await _backchannelPlayer.stop();
+    _interrupted = false;
+    _setState(
+      failure != null ? SessionState(SessionStatus.failed, failure) : SessionState.idle,
+    );
+  }
+
+  void setMicEnabled(bool enabled) => _client?.setMicEnabled(enabled);
+
+  void _wireCallbacks(WebRtcClient client) {
+    client.onDataChannelOpen = _sendInitialEvents;
+    client.onServerEvent = _handle;
+    client.onConnectionStateChange = _handleConnectionState;
+  }
+
+  void _sendInitialEvents() {
+    final client = _client;
+    if (client == null) return;
+    client.send(sessionUpdateEvent(config));
+    client.send(conversationItemCreateEvent(config.greetingPrompt));
+    client.send(responseCreateEvent());
+    _setState(SessionState.connected);
+  }
+
+  void _handle(ServerEvent event) {
+    switch (event) {
+      case SpeechStarted():
+        // Barge-in: silence the agent immediately, cancel its response.
+        _interrupted = true;
+        _client?.setAgentAudioEnabled(false);
+        _client?.send(responseCancelEvent());
+      case OutputItemAdded():
+        if (_interrupted) {
+          _client?.setAgentAudioEnabled(true);
+          _interrupted = false;
+        }
+      case BackchannelAudioDelta(:final base64Pcm16):
+        _backchannelPlayer.enqueue(base64Pcm16);
+      case BackchannelAudioDone():
+        _backchannelPlayer.flush();
+      default:
+        break;
+    }
+    onEvent?.call(event);
+  }
+
+  void _handleConnectionState(RTCPeerConnectionState pcState) {
+    switch (pcState) {
+      case RTCPeerConnectionState.RTCPeerConnectionStateFailed:
+        disconnect(failure: 'Connection lost.');
+      case RTCPeerConnectionState.RTCPeerConnectionStateDisconnected:
+      case RTCPeerConnectionState.RTCPeerConnectionStateClosed:
+        if (_state.status == SessionStatus.connected) disconnect();
+      default:
+        break;
+    }
+  }
+}

--- a/realtime/flutter/webrtc/lib/realtime/session_config.dart
+++ b/realtime/flutter/webrtc/lib/realtime/session_config.dart
@@ -1,0 +1,91 @@
+class BackchannelConfig {
+  const BackchannelConfig({
+    this.maxPerTurn = 3,
+    this.minGapMs = 4000,
+    this.minSpeechMs = 800,
+    this.volumeGain = 0.6,
+    this.deciderKind = 'llm',
+    this.ruleFireProbability = 1.0,
+  });
+
+  final int maxPerTurn;
+  final int minGapMs;
+  final int minSpeechMs;
+  final double volumeGain;
+  final String deciderKind;
+  final double ruleFireProbability;
+}
+
+class ResponsivenessConfig {
+  const ResponsivenessConfig({
+    this.initialWaitTimeoutMs = 1200,
+    this.maxInitialPerTurn = 1,
+    this.minFillerGapMs = 8000,
+    this.maxTokens = 12,
+    this.enableOnFirstReply = false,
+  });
+
+  final int initialWaitTimeoutMs;
+  final int maxInitialPerTurn;
+  final int minFillerGapMs;
+  final int maxTokens;
+  final bool enableOnFirstReply;
+}
+
+class WebSearchConfig {
+  const WebSearchConfig({
+    this.engine = 'google',
+    this.maxResults = 3,
+    this.maxSteps = 1,
+  });
+
+  final String engine;
+  final int maxResults;
+  final int maxSteps;
+}
+
+class SessionConfig {
+  const SessionConfig({
+    required this.model,
+    required this.instructions,
+    required this.ttsModel,
+    required this.voice,
+    required this.greetingPrompt,
+    this.temperature,
+    this.maxOutputTokens,
+    this.speechSpeed,
+    this.transcriptionModel,
+    this.transcriptionLanguage,
+    this.noiseReduction,
+    this.eagerness = 'high',
+    this.webSearch,
+    this.createResponse = true,
+    this.interruptResponse = true,
+    this.backchannel,
+    this.responsiveness,
+  });
+
+  final String model;
+  final String instructions;
+  final String ttsModel;
+  final String voice;
+  final String greetingPrompt;
+
+  final double? temperature;
+  final int? maxOutputTokens;
+  final double? speechSpeed;
+
+  final String? transcriptionModel;
+  final String? transcriptionLanguage;
+  final String? noiseReduction;
+
+  /// This example uses semantic VAD only; the native examples also expose server VAD.
+  final String eagerness;
+
+  final WebSearchConfig? webSearch;
+  final bool createResponse;
+  final bool interruptResponse;
+
+  final BackchannelConfig? backchannel;
+  final ResponsivenessConfig? responsiveness;
+}

--- a/realtime/flutter/webrtc/lib/realtime/signaling_api.dart
+++ b/realtime/flutter/webrtc/lib/realtime/signaling_api.dart
@@ -1,0 +1,65 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import '../auth/auth_provider.dart';
+
+class SignalingException implements Exception {
+  SignalingException(this.message);
+  final String message;
+  @override
+  String toString() => message;
+}
+
+class SignalingApi {
+  SignalingApi(this.credentials, {http.Client? client})
+      : _client = client ?? http.Client();
+
+  final RealtimeCredentials credentials;
+  final http.Client _client;
+
+  Future<List<IceServer>> fetchIceServers() async {
+    final preFetched = credentials.preFetchedIceServers;
+    if (preFetched != null) return preFetched;
+
+    final url = Uri.parse('${credentials.apiBaseUrl}/v1/realtime/ice-servers');
+    final response = await _client.get(
+      url,
+      headers: {'Authorization': credentials.authorizationHeader},
+    );
+    _ensureOk(response);
+    final json = jsonDecode(response.body) as Map<String, dynamic>;
+    return (json['ice_servers'] as List)
+        .map((e) => IceServer.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<String> postOffer(String sdp) async {
+    final url = Uri.parse(
+      credentials.callsUrl ?? '${credentials.apiBaseUrl}/v1/realtime/calls',
+    );
+    final response = await _client.post(
+      url,
+      headers: {
+        'Authorization': credentials.authorizationHeader,
+        'Content-Type': 'application/sdp',
+      },
+      body: sdp,
+    );
+    _ensureOk(response);
+    if (response.body.isEmpty) {
+      throw SignalingException('Malformed response from Inworld API.');
+    }
+    return response.body;
+  }
+
+  void _ensureOk(http.Response response) {
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      final body = response.body;
+      throw SignalingException(
+        'Inworld API error (HTTP ${response.statusCode}): '
+        '${body.substring(0, body.length < 200 ? body.length : 200)}',
+      );
+    }
+  }
+}

--- a/realtime/flutter/webrtc/lib/secrets.dart.example
+++ b/realtime/flutter/webrtc/lib/secrets.dart.example
@@ -1,0 +1,4 @@
+// Copy this file to `secrets.dart` and paste your base64 INWORLD_API_KEY, or leave
+// it empty and enter the key at runtime in the app's Settings screen (gear icon).
+// `secrets.dart` is gitignored. Never commit a real key.
+const String inworldApiKey = '';

--- a/realtime/flutter/webrtc/lib/state/conversation_controller.dart
+++ b/realtime/flutter/webrtc/lib/state/conversation_controller.dart
@@ -1,0 +1,178 @@
+import 'package:flutter/foundation.dart';
+
+import '../realtime/events/server_event.dart';
+import '../realtime/realtime_session.dart';
+import '../storage/settings.dart';
+import 'transcript_item.dart';
+
+class ConversationController extends ChangeNotifier {
+  ConversationController(this._settings);
+
+  final SettingsStore _settings;
+  RealtimeSession? _session;
+
+  final List<TranscriptItem> _transcript = [];
+  List<TranscriptItem> get transcript => List.unmodifiable(_transcript);
+
+  SessionState _state = SessionState.idle;
+  SessionState get state => _state;
+
+  bool _isMicMuted = false;
+  bool get isMicMuted => _isMicMuted;
+
+  int _nextId = 0;
+  int? _streamingAgentId;
+  int? _streamingUserId;
+
+  bool get isConnected => _state.status == SessionStatus.connected;
+  bool get isBusy => _state.status == SessionStatus.connecting;
+  String? get errorMessage =>
+      _state.status == SessionStatus.failed ? _state.message : null;
+
+  Future<void> connect() async {
+    _transcript.clear();
+    _streamingAgentId = null;
+    _streamingUserId = null;
+    _isMicMuted = false;
+    notifyListeners();
+
+    final session = RealtimeSession(
+      authProvider: _settings.makeAuthProvider(),
+      config: _settings.makeSessionConfig(),
+    );
+    session.onStateChange = (state) {
+      _state = state;
+      notifyListeners();
+    };
+    session.onEvent = _handle;
+    _session = session;
+    await session.connect();
+  }
+
+  Future<void> disconnect() async {
+    await _session?.disconnect();
+    _session = null;
+    _streamingAgentId = null;
+    _streamingUserId = null;
+    notifyListeners();
+  }
+
+  void setMicMuted(bool muted) {
+    _isMicMuted = muted;
+    _session?.setMicEnabled(!muted);
+    notifyListeners();
+  }
+
+  void _handle(ServerEvent event) {
+    switch (event) {
+      case OutputTextDelta(:final delta):
+        _appendAgentDelta(delta);
+      case TranscriptDone(:final text):
+        _finalizeAgentItem(text);
+      case InputTranscriptionDelta(:final delta):
+        _appendUserDelta(delta);
+      case InputTranscriptionCompleted(:final transcript):
+        _finalizeUserItem(transcript);
+      case SpeechStarted():
+        _dropStreamingAgentItem();
+      case ResponseDone():
+        _finalizeAgentItem(null);
+      case ErrorEvent(:final message):
+        _state = SessionState(SessionStatus.failed, message);
+      default:
+        // Back-channel audio is played in the realtime layer; nothing to show.
+        break;
+    }
+    notifyListeners();
+  }
+
+  void _appendAgentDelta(String delta) {
+    if (delta.isEmpty) return;
+    final index = _indexOf(_streamingAgentId);
+    if (index != null) {
+      _transcript[index].text += delta;
+    } else {
+      final item = TranscriptItem(
+        id: _nextId++,
+        role: TranscriptRole.agent,
+        text: delta,
+        isStreaming: true,
+      );
+      _streamingAgentId = item.id;
+      _transcript.add(item);
+    }
+  }
+
+  void _finalizeAgentItem(String? text) {
+    final index = _indexOf(_streamingAgentId);
+    _streamingAgentId = null;
+    if (index == null) return;
+    if (text != null && text.isNotEmpty) _transcript[index].text = text;
+    _transcript[index].isStreaming = false;
+  }
+
+  void _appendUserDelta(String delta) {
+    if (delta.isEmpty) return;
+    final index = _indexOf(_streamingUserId);
+    if (index != null) {
+      _transcript[index].text = reconcileTranscript(_transcript[index].text, delta);
+    } else {
+      final item = TranscriptItem(
+        id: _nextId++,
+        role: TranscriptRole.user,
+        text: delta,
+        isStreaming: true,
+      );
+      _streamingUserId = item.id;
+      _transcript.add(item);
+    }
+  }
+
+  /// Some STT providers (e.g. Soniox) emit each partial as the FULL text-so-far
+  /// rather than an incremental chunk, so blindly appending duplicates the
+  /// transcript. Tolerate both shapes; the final `completed` transcript is
+  /// authoritative regardless.
+  static String reconcileTranscript(String existing, String delta) {
+    if (existing.isEmpty) return delta;
+    if (delta == existing) return existing; // cumulative re-send of same text
+    if (delta.startsWith(existing)) return delta; // cumulative growth → replace
+    if (existing.startsWith(delta)) return existing; // stale shorter snapshot → keep
+    return existing + delta; // genuine incremental chunk → append
+  }
+
+  void _finalizeUserItem(String transcript) {
+    final trimmed = transcript.trim();
+    final index = _indexOf(_streamingUserId);
+    if (index != null) {
+      if (trimmed.isNotEmpty) {
+        _transcript[index].text = trimmed;
+        _transcript[index].isStreaming = false;
+      } else if (_transcript[index].text.isEmpty) {
+        _transcript.removeAt(index);
+      } else {
+        _transcript[index].isStreaming = false;
+      }
+      _streamingUserId = null;
+    } else if (trimmed.isNotEmpty) {
+      _transcript.add(TranscriptItem(
+        id: _nextId++,
+        role: TranscriptRole.user,
+        text: trimmed,
+      ));
+    }
+  }
+
+  void _dropStreamingAgentItem() {
+    final id = _streamingAgentId;
+    if (id != null) {
+      _transcript.removeWhere((item) => item.id == id);
+      _streamingAgentId = null;
+    }
+  }
+
+  int? _indexOf(int? id) {
+    if (id == null) return null;
+    final index = _transcript.indexWhere((item) => item.id == id);
+    return index >= 0 ? index : null;
+  }
+}

--- a/realtime/flutter/webrtc/lib/state/transcript_item.dart
+++ b/realtime/flutter/webrtc/lib/state/transcript_item.dart
@@ -1,0 +1,15 @@
+enum TranscriptRole { user, agent }
+
+class TranscriptItem {
+  TranscriptItem({
+    required this.id,
+    required this.role,
+    required this.text,
+    this.isStreaming = false,
+  });
+
+  final int id;
+  final TranscriptRole role;
+  String text;
+  bool isStreaming;
+}

--- a/realtime/flutter/webrtc/lib/storage/settings.dart
+++ b/realtime/flutter/webrtc/lib/storage/settings.dart
@@ -1,0 +1,158 @@
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../auth/auth_provider.dart';
+import '../realtime/session_config.dart';
+import '../secrets.dart';
+
+enum AuthMode {
+  basic('API Key (Basic)'),
+  backendJwt('Backend JWT');
+
+  const AuthMode(this.label);
+  final String label;
+}
+
+enum NoiseReductionMode {
+  off(null, 'Server default'),
+  nearField('near_field', 'Near field'),
+  farField('far_field', 'Far field');
+
+  const NoiseReductionMode(this.wire, this.label);
+  final String? wire;
+  final String label;
+}
+
+const eagernessOptions = ['low', 'medium', 'high', 'auto'];
+
+/// Persists settings in SharedPreferences — the Flutter analog of the Android
+/// example's DataStore. Like that example, the API key is stored in plain prefs
+/// for demo simplicity; a production app should use flutter_secure_storage.
+class SettingsStore extends ChangeNotifier {
+  SettingsStore._(this._prefs);
+
+  final SharedPreferences _prefs;
+
+  static Future<SettingsStore> load() async {
+    return SettingsStore._(await SharedPreferences.getInstance());
+  }
+
+  T _get<T>(String key, T fallback) => (_prefs.get(key) as T?) ?? fallback;
+
+  Future<void> _set(String key, Object value) async {
+    switch (value) {
+      case String v:
+        await _prefs.setString(key, v);
+      case int v:
+        await _prefs.setInt(key, v);
+      case double v:
+        await _prefs.setDouble(key, v);
+      case bool v:
+        await _prefs.setBool(key, v);
+    }
+    notifyListeners();
+  }
+
+  // Auth
+  String get apiKey => _get('apiKey', inworldApiKey);
+  set apiKey(String v) => _set('apiKey', v);
+  AuthMode get authMode =>
+      AuthMode.values.byNameOrNull(_get('authMode', '')) ?? AuthMode.basic;
+  set authMode(AuthMode v) => _set('authMode', v.name);
+  String get backendUrl => _get('backendUrl', 'http://localhost:3000');
+  set backendUrl(String v) => _set('backendUrl', v);
+
+  // Model
+  String get model => _get('model', 'inworld/models/gemma-4-26b-a4b-it');
+  set model(String v) => _set('model', v);
+  String get instructions =>
+      _get('instructions', 'You are a friendly voice assistant. Keep responses brief.');
+  set instructions(String v) => _set('instructions', v);
+  String get greetingPrompt =>
+      _get('greetingPrompt', 'Say hello and ask how you can help. One sentence max.');
+  set greetingPrompt(String v) => _set('greetingPrompt', v);
+  bool get temperatureEnabled => _get('temperatureEnabled', false);
+  set temperatureEnabled(bool v) => _set('temperatureEnabled', v);
+  double get temperature => _get('temperature', 0.7);
+  set temperature(double v) => _set('temperature', v);
+
+  /// 0 means "server default" (not sent).
+  int get maxOutputTokens => _get('maxOutputTokens', 0);
+  set maxOutputTokens(int v) => _set('maxOutputTokens', v);
+  bool get webSearchEnabled => _get('webSearchEnabled', true);
+  set webSearchEnabled(bool v) => _set('webSearchEnabled', v);
+
+  // Voice output
+  String get ttsModel => _get('ttsModel', 'inworld-tts-2');
+  set ttsModel(String v) => _set('ttsModel', v);
+  String get voice => _get('voice', 'Clive');
+  set voice(String v) => _set('voice', v);
+  double get speechSpeed {
+    final v = _get('speechSpeed', 1.0);
+    return (v >= 0.5 && v <= 1.5) ? v : 1.0;
+  }
+
+  set speechSpeed(double v) => _set('speechSpeed', v.clamp(0.5, 1.5));
+
+  // Audio input
+  String get transcriptionModel => _get('transcriptionModel', '');
+  set transcriptionModel(String v) => _set('transcriptionModel', v);
+  String get transcriptionLanguage => _get('transcriptionLanguage', '');
+  set transcriptionLanguage(String v) => _set('transcriptionLanguage', v);
+  NoiseReductionMode get noiseReduction =>
+      NoiseReductionMode.values.byNameOrNull(_get('noiseReduction', '')) ??
+      NoiseReductionMode.off;
+  set noiseReduction(NoiseReductionMode v) => _set('noiseReduction', v.name);
+
+  // Turn detection (semantic VAD)
+  String get eagerness => _get('eagerness', 'high');
+  set eagerness(String v) => _set('eagerness', v);
+  bool get createResponse => _get('createResponse', true);
+  set createResponse(bool v) => _set('createResponse', v);
+  bool get interruptResponse => _get('interruptResponse', true);
+  set interruptResponse(bool v) => _set('interruptResponse', v);
+
+  // Back-channel
+  bool get backchannelEnabled => _get('backchannelEnabled', true);
+  set backchannelEnabled(bool v) => _set('backchannelEnabled', v);
+
+  // Responsiveness
+  bool get responsivenessEnabled => _get('responsivenessEnabled', true);
+  set responsivenessEnabled(bool v) => _set('responsivenessEnabled', v);
+
+  AuthProvider makeAuthProvider() => switch (authMode) {
+        AuthMode.basic => BasicAuthProvider(apiKey),
+        AuthMode.backendJwt => BackendJwtAuthProvider(backendUrl),
+      };
+
+  SessionConfig makeSessionConfig() => SessionConfig(
+        model: model,
+        instructions: instructions,
+        temperature: temperatureEnabled ? temperature : null,
+        maxOutputTokens: maxOutputTokens > 0 ? maxOutputTokens : null,
+        ttsModel: ttsModel,
+        voice: voice,
+        speechSpeed: speechSpeed == 1.0 ? null : speechSpeed,
+        transcriptionModel: transcriptionModel.isEmpty ? null : transcriptionModel,
+        transcriptionLanguage:
+            transcriptionLanguage.isEmpty ? null : transcriptionLanguage,
+        noiseReduction: noiseReduction.wire,
+        eagerness: eagerness,
+        webSearch: webSearchEnabled ? const WebSearchConfig() : null,
+        createResponse: createResponse,
+        interruptResponse: interruptResponse,
+        backchannel: backchannelEnabled ? const BackchannelConfig() : null,
+        responsiveness:
+            responsivenessEnabled ? const ResponsivenessConfig() : null,
+        greetingPrompt: greetingPrompt,
+      );
+}
+
+extension<T extends Enum> on List<T> {
+  T? byNameOrNull(String name) {
+    for (final value in this) {
+      if (value.name == name) return value;
+    }
+    return null;
+  }
+}

--- a/realtime/flutter/webrtc/lib/ui/conversation_screen.dart
+++ b/realtime/flutter/webrtc/lib/ui/conversation_screen.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../state/conversation_controller.dart';
+import 'message_bubble.dart';
+import 'settings_screen.dart';
+
+class ConversationScreen extends StatelessWidget {
+  const ConversationScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = context.watch<ConversationController>();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Inworld Voice Agent'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.settings),
+            onPressed: controller.isConnected || controller.isBusy
+                ? null
+                : () => Navigator.of(context).push(
+                      MaterialPageRoute(builder: (_) => const SettingsScreen()),
+                    ),
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          if (controller.errorMessage != null)
+            _Banner(message: controller.errorMessage!),
+          Expanded(
+            child: controller.transcript.isEmpty
+                ? const _EmptyState()
+                : ListView.builder(
+                    padding: const EdgeInsets.symmetric(vertical: 8),
+                    itemCount: controller.transcript.length,
+                    itemBuilder: (_, i) =>
+                        MessageBubble(item: controller.transcript[i]),
+                  ),
+          ),
+          _Controls(controller: controller),
+        ],
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Text(
+          'Tap Connect and start talking.',
+          textAlign: TextAlign.center,
+          style: Theme.of(context).textTheme.bodyLarge,
+        ),
+      ),
+    );
+  }
+}
+
+class _Banner extends StatelessWidget {
+  const _Banner({required this.message});
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Container(
+      width: double.infinity,
+      color: scheme.errorContainer,
+      padding: const EdgeInsets.all(12),
+      child: Text(message, style: TextStyle(color: scheme.onErrorContainer)),
+    );
+  }
+}
+
+class _Controls extends StatelessWidget {
+  const _Controls({required this.controller});
+  final ConversationController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      top: false,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          children: [
+            if (controller.isConnected)
+              IconButton.filledTonal(
+                icon: Icon(controller.isMicMuted ? Icons.mic_off : Icons.mic),
+                onPressed: () => controller.setMicMuted(!controller.isMicMuted),
+              ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: FilledButton.icon(
+                icon: controller.isBusy
+                    ? const SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : Icon(controller.isConnected ? Icons.call_end : Icons.call),
+                label: Text(
+                  controller.isBusy
+                      ? 'Connecting…'
+                      : controller.isConnected
+                          ? 'Disconnect'
+                          : 'Connect',
+                ),
+                style: controller.isConnected
+                    ? FilledButton.styleFrom(
+                        backgroundColor: Theme.of(context).colorScheme.error,
+                      )
+                    : null,
+                onPressed: controller.isBusy
+                    ? null
+                    : () => controller.isConnected
+                        ? controller.disconnect()
+                        : controller.connect(),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/realtime/flutter/webrtc/lib/ui/message_bubble.dart
+++ b/realtime/flutter/webrtc/lib/ui/message_bubble.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+import '../state/transcript_item.dart';
+
+class MessageBubble extends StatelessWidget {
+  const MessageBubble({super.key, required this.item});
+
+  final TranscriptItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    final isUser = item.role == TranscriptRole.user;
+    final scheme = Theme.of(context).colorScheme;
+    final bg = isUser ? scheme.primaryContainer : scheme.surfaceContainerHighest;
+    final fg = isUser ? scheme.onPrimaryContainer : scheme.onSurface;
+
+    return Align(
+      alignment: isUser ? Alignment.centerRight : Alignment.centerLeft,
+      child: Container(
+        margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 12),
+        padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 14),
+        constraints: BoxConstraints(
+          maxWidth: MediaQuery.sizeOf(context).width * 0.78,
+        ),
+        decoration: BoxDecoration(
+          color: bg,
+          borderRadius: BorderRadius.circular(16),
+        ),
+        child: Text(
+          item.text.isEmpty && item.isStreaming ? '…' : item.text,
+          style: TextStyle(
+            color: fg,
+            fontStyle: item.isStreaming ? FontStyle.italic : FontStyle.normal,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/realtime/flutter/webrtc/lib/ui/settings_screen.dart
+++ b/realtime/flutter/webrtc/lib/ui/settings_screen.dart
@@ -1,0 +1,168 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../storage/settings.dart';
+
+class SettingsScreen extends StatefulWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  State<SettingsScreen> createState() => _SettingsScreenState();
+}
+
+class _SettingsScreenState extends State<SettingsScreen> {
+  late final SettingsStore _settings = context.read<SettingsStore>();
+
+  // Uncontrolled text controllers, seeded once — writing back into the field on
+  // every keystroke via the store round-trip drops characters (a bug we hit on
+  // the native apps), so the store is written on change but never read back here.
+  late final _controllers = <String, TextEditingController>{
+    'apiKey': TextEditingController(text: _settings.apiKey),
+    'backendUrl': TextEditingController(text: _settings.backendUrl),
+    'model': TextEditingController(text: _settings.model),
+    'instructions': TextEditingController(text: _settings.instructions),
+    'greeting': TextEditingController(text: _settings.greetingPrompt),
+    'ttsModel': TextEditingController(text: _settings.ttsModel),
+    'voice': TextEditingController(text: _settings.voice),
+  };
+
+  @override
+  void dispose() {
+    for (final c in _controllers.values) {
+      c.dispose();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Settings')),
+      body: AnimatedBuilder(
+        animation: _settings,
+        builder: (context, _) => ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            _section('Authentication'),
+            DropdownButtonFormField<AuthMode>(
+              initialValue: _settings.authMode,
+              decoration: const InputDecoration(labelText: 'Auth mode'),
+              items: [
+                for (final m in AuthMode.values)
+                  DropdownMenuItem(value: m, child: Text(m.label)),
+              ],
+              onChanged: (m) => _settings.authMode = m!,
+            ),
+            if (_settings.authMode == AuthMode.basic)
+              _field('apiKey', 'INWORLD API key (base64)',
+                  (v) => _settings.apiKey = v, obscure: true)
+            else
+              _field('backendUrl', 'Backend URL',
+                  (v) => _settings.backendUrl = v),
+            _section('Model'),
+            _field('model', 'LLM model', (v) => _settings.model = v),
+            _field('instructions', 'Instructions',
+                (v) => _settings.instructions = v, maxLines: 3),
+            _field('greeting', 'Greeting prompt',
+                (v) => _settings.greetingPrompt = v, maxLines: 2),
+            SwitchListTile(
+              title: const Text('Google web search'),
+              value: _settings.webSearchEnabled,
+              onChanged: (v) => _settings.webSearchEnabled = v,
+            ),
+            SwitchListTile(
+              title: const Text('Custom temperature'),
+              value: _settings.temperatureEnabled,
+              onChanged: (v) => _settings.temperatureEnabled = v,
+            ),
+            if (_settings.temperatureEnabled)
+              _slider('Temperature', _settings.temperature, 0, 2,
+                  (v) => _settings.temperature = v),
+            _section('Voice output'),
+            _field('ttsModel', 'TTS model', (v) => _settings.ttsModel = v),
+            _field('voice', 'Voice', (v) => _settings.voice = v),
+            _slider('Speed', _settings.speechSpeed, 0.5, 1.5,
+                (v) => _settings.speechSpeed = v),
+            _section('Turn detection'),
+            DropdownButtonFormField<String>(
+              initialValue: _settings.eagerness,
+              decoration: const InputDecoration(labelText: 'Eagerness'),
+              items: [
+                for (final e in eagernessOptions)
+                  DropdownMenuItem(value: e, child: Text(e)),
+              ],
+              onChanged: (e) => _settings.eagerness = e!,
+            ),
+            SwitchListTile(
+              title: const Text('Create response'),
+              value: _settings.createResponse,
+              onChanged: (v) => _settings.createResponse = v,
+            ),
+            SwitchListTile(
+              title: const Text('Interrupt response (barge-in)'),
+              value: _settings.interruptResponse,
+              onChanged: (v) => _settings.interruptResponse = v,
+            ),
+            _section('Conversational features'),
+            SwitchListTile(
+              title: const Text('Back-channel ("uh-huh")'),
+              value: _settings.backchannelEnabled,
+              onChanged: (v) => _settings.backchannelEnabled = v,
+            ),
+            SwitchListTile(
+              title: const Text('Responsiveness (low-latency filler)'),
+              value: _settings.responsivenessEnabled,
+              onChanged: (v) => _settings.responsivenessEnabled = v,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _section(String title) => Padding(
+        padding: const EdgeInsets.only(top: 20, bottom: 8),
+        child: Text(title, style: Theme.of(context).textTheme.titleMedium),
+      );
+
+  Widget _field(
+    String key,
+    String label,
+    ValueChanged<String> onChanged, {
+    bool obscure = false,
+    int maxLines = 1,
+  }) =>
+      Padding(
+        padding: const EdgeInsets.symmetric(vertical: 6),
+        child: TextField(
+          controller: _controllers[key],
+          obscureText: obscure,
+          maxLines: maxLines,
+          decoration: InputDecoration(labelText: label),
+          onChanged: onChanged,
+        ),
+      );
+
+  Widget _slider(
+    String label,
+    double value,
+    double min,
+    double max,
+    ValueChanged<double> onChanged,
+  ) =>
+      Padding(
+        padding: const EdgeInsets.symmetric(vertical: 6),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('$label: ${value.toStringAsFixed(2)}'),
+            Slider(
+              value: value.clamp(min, max),
+              min: min,
+              max: max,
+              onChanged: onChanged,
+            ),
+          ],
+        ),
+      );
+}

--- a/realtime/flutter/webrtc/lib/webrtc/ice_gathering_waiter.dart
+++ b/realtime/flutter/webrtc/lib/webrtc/ice_gathering_waiter.dart
@@ -1,0 +1,29 @@
+import 'dart:async';
+
+/// Waits for ICE gathering: resolves on `complete`, 500 ms of candidate silence,
+/// or a 3 s cap — mirroring the JS example. Candidates accumulate inside the peer
+/// connection's local description, so only the wait matters.
+class IceGatheringWaiter {
+  final Completer<void> _completer = Completer<void>();
+  Timer? _debounce;
+  Timer? _timeout;
+
+  Future<void> get done => _completer.future;
+
+  void start() {
+    _timeout = Timer(const Duration(seconds: 3), _finish);
+  }
+
+  void candidateGenerated() {
+    _debounce?.cancel();
+    _debounce = Timer(const Duration(milliseconds: 500), _finish);
+  }
+
+  void gatheringComplete() => _finish();
+
+  void _finish() {
+    _debounce?.cancel();
+    _timeout?.cancel();
+    if (!_completer.isCompleted) _completer.complete();
+  }
+}

--- a/realtime/flutter/webrtc/lib/webrtc/webrtc_client.dart
+++ b/realtime/flutter/webrtc/lib/webrtc/webrtc_client.dart
@@ -1,0 +1,119 @@
+import 'dart:convert';
+
+import 'package:flutter_webrtc/flutter_webrtc.dart';
+
+import '../auth/auth_provider.dart';
+import '../realtime/events/server_event.dart';
+import 'ice_gathering_waiter.dart';
+
+/// Thin wrapper over a single audio-only WebRTC peer connection plus the
+/// `oai-events` data channel. Ports the native examples' WebRTCClient.
+class WebRtcClient {
+  WebRtcClient._(this._pc, this._dc, this._localStream);
+
+  final RTCPeerConnection _pc;
+  final RTCDataChannel _dc;
+  final MediaStream _localStream;
+  final IceGatheringWaiter _iceWaiter = IceGatheringWaiter();
+  MediaStreamTrack? _remoteAudioTrack;
+
+  void Function()? onDataChannelOpen;
+  void Function(ServerEvent event)? onServerEvent;
+  void Function(RTCPeerConnectionState state)? onConnectionStateChange;
+
+  static Future<WebRtcClient> create(List<IceServer> iceServers) async {
+    final configuration = <String, dynamic>{
+      'sdpSemantics': 'unified-plan',
+      'iceServers': iceServers
+          .map((s) => <String, dynamic>{
+                'urls': s.urls,
+                if (s.username != null) 'username': s.username,
+                if (s.credential != null) 'credential': s.credential,
+              })
+          .toList(),
+    };
+
+    final pc = await createPeerConnection(configuration);
+    final dc = await pc.createDataChannel(
+      'oai-events',
+      RTCDataChannelInit()..ordered = true,
+    );
+
+    // Audio-only capture. Echo cancellation / noise suppression are applied by the
+    // platform voice-processing unit once the track is attached to the connection.
+    final localStream = await navigator.mediaDevices.getUserMedia({
+      'audio': true,
+      'video': false,
+    });
+    for (final track in localStream.getAudioTracks()) {
+      await pc.addTrack(track, localStream);
+    }
+
+    final client = WebRtcClient._(pc, dc, localStream);
+    client._wire();
+    return client;
+  }
+
+  void _wire() {
+    _pc.onIceGatheringState = (state) {
+      if (state == RTCIceGatheringState.RTCIceGatheringStateComplete) {
+        _iceWaiter.gatheringComplete();
+      }
+    };
+    _pc.onIceCandidate = (_) => _iceWaiter.candidateGenerated();
+    _pc.onConnectionState = (state) => onConnectionStateChange?.call(state);
+    _pc.onTrack = (RTCTrackEvent event) {
+      if (event.track.kind == 'audio') _remoteAudioTrack = event.track;
+    };
+
+    _dc.onDataChannelState = (state) {
+      if (state == RTCDataChannelState.RTCDataChannelOpen) {
+        onDataChannelOpen?.call();
+      }
+    };
+    _dc.onMessage = (RTCDataChannelMessage message) {
+      if (!message.isBinary) {
+        onServerEvent?.call(ServerEvent.decode(message.text));
+      }
+    };
+  }
+
+  Future<String> makeOfferSdp() async {
+    _iceWaiter.start();
+    final offer = await _pc.createOffer();
+    await _pc.setLocalDescription(offer);
+    await _iceWaiter.done;
+    final local = await _pc.getLocalDescription();
+    return local!.sdp!;
+  }
+
+  Future<void> setAnswer(String sdp) async {
+    await _pc.setRemoteDescription(RTCSessionDescription(sdp, 'answer'));
+  }
+
+  void send(Map<String, dynamic> event) {
+    if (_dc.state != RTCDataChannelState.RTCDataChannelOpen) return;
+    _dc.send(RTCDataChannelMessage(jsonEncode(event)));
+  }
+
+  void setAgentAudioEnabled(bool enabled) {
+    _remoteAudioTrack?.enabled = enabled;
+  }
+
+  void setMicEnabled(bool enabled) {
+    for (final track in _localStream.getAudioTracks()) {
+      track.enabled = enabled;
+    }
+  }
+
+  Future<void> close() async {
+    // Dispose order matters: data channel → tracks → peer connection.
+    await _dc.close();
+    for (final track in _localStream.getAudioTracks()) {
+      await track.stop();
+    }
+    await _localStream.dispose();
+    await _pc.close();
+    await _pc.dispose();
+  }
+}

--- a/realtime/flutter/webrtc/pubspec.yaml
+++ b/realtime/flutter/webrtc/pubspec.yaml
@@ -1,0 +1,30 @@
+name: inworld_voice_agent
+description: Inworld Realtime API voice agent over WebRTC — Flutter example.
+publish_to: "none"
+version: 1.0.0+1
+
+environment:
+  sdk: ">=3.5.0 <4.0.0"
+  flutter: ">=3.24.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  # Stock org.webrtc / WebRTC.framework bindings (unified plan, data channels, audio tracks).
+  flutter_webrtc: ^0.12.5
+  # Settings persistence, the Flutter analog of iOS UserDefaults / Android DataStore.
+  shared_preferences: ^2.3.2
+  # Runtime microphone permission on both platforms.
+  permission_handler: ^11.3.1
+  # Back-channel PCM playback: chunks are buffered, wrapped in a WAV, and played as a clip.
+  audioplayers: ^6.1.0
+  http: ^1.2.2
+  provider: ^6.1.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^4.0.0
+
+flutter:
+  uses-material-design: true

--- a/realtime/flutter/webrtc/test/client_event_encoding_test.dart
+++ b/realtime/flutter/webrtc/test/client_event_encoding_test.dart
@@ -1,0 +1,162 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:inworld_voice_agent/realtime/events/client_events.dart';
+import 'package:inworld_voice_agent/realtime/session_config.dart';
+
+SessionConfig baseConfig({
+  WebSearchConfig? webSearch,
+  BackchannelConfig? backchannel,
+  ResponsivenessConfig? responsiveness,
+  double? speechSpeed,
+  double? temperature,
+  int? maxOutputTokens,
+  String? transcriptionModel,
+  String? transcriptionLanguage,
+  String? noiseReduction,
+}) =>
+    SessionConfig(
+      model: 'openai/gpt-4o-mini',
+      instructions: 'Be brief.',
+      ttsModel: 'inworld-tts-2',
+      voice: 'Clive',
+      greetingPrompt: 'Say hello.',
+      webSearch: webSearch,
+      backchannel: backchannel,
+      responsiveness: responsiveness,
+      speechSpeed: speechSpeed,
+      temperature: temperature,
+      maxOutputTokens: maxOutputTokens,
+      transcriptionModel: transcriptionModel,
+      transcriptionLanguage: transcriptionLanguage,
+      noiseReduction: noiseReduction,
+    );
+
+void main() {
+  group('sessionUpdateEvent', () {
+    test('default shape', () {
+      final json = sessionUpdateEvent(baseConfig());
+      expect(json['type'], 'session.update');
+
+      final session = json['session'] as Map<String, dynamic>;
+      expect(session['type'], 'realtime');
+      expect(session['model'], 'openai/gpt-4o-mini');
+      expect(session['instructions'], 'Be brief.');
+      expect(session['output_modalities'], ['audio', 'text']);
+      expect(session.containsKey('temperature'), isFalse);
+      expect(session.containsKey('max_output_tokens'), isFalse);
+      expect(session.containsKey('tools'), isFalse);
+      expect(session.containsKey('providerData'), isFalse);
+
+      final input = (session['audio'] as Map)['input'] as Map;
+      expect(input.containsKey('transcription'), isFalse);
+      expect(input.containsKey('noise_reduction'), isFalse);
+
+      final td = input['turn_detection'] as Map;
+      expect(td['type'], 'semantic_vad');
+      expect(td['eagerness'], 'high');
+      expect(td['create_response'], true);
+      expect(td['interrupt_response'], true);
+
+      final output = (session['audio'] as Map)['output'] as Map;
+      expect(output['model'], 'inworld-tts-2');
+      expect(output['voice'], 'Clive');
+      expect(output.containsKey('speed'), isFalse);
+    });
+
+    test('web search encodes a tool with camelCase providerData', () {
+      final config = baseConfig(webSearch: const WebSearchConfig());
+      final raw = jsonEncode(sessionUpdateEvent(config));
+      expect(raw.contains('"providerData"'), isTrue);
+      expect(raw.contains('"provider_data"'), isFalse);
+
+      final session = sessionUpdateEvent(config)['session'] as Map<String, dynamic>;
+      final tools = session['tools'] as List;
+      expect(tools.length, 1);
+      final tool = tools.first as Map;
+      expect(tool['type'], 'web_search');
+      final pd = tool['providerData'] as Map;
+      expect(pd['engine'], 'google');
+      expect(pd['max_results'], 3);
+      expect(pd['max_steps'], 1);
+    });
+
+    test('providerData key stays camelCase while inner keys are snake_case', () {
+      final config = baseConfig(backchannel: const BackchannelConfig());
+      final raw = jsonEncode(sessionUpdateEvent(config));
+      expect(raw.contains('"providerData"'), isTrue);
+      expect(raw.contains('"provider_data"'), isFalse);
+      expect(raw.contains('"max_per_turn"'), isTrue);
+      expect(raw.contains('"output_modalities"'), isTrue);
+    });
+
+    test('providerData omitted by default', () {
+      final session = sessionUpdateEvent(baseConfig())['session'] as Map;
+      expect(session.containsKey('providerData'), isFalse);
+    });
+
+    test('back-channel and responsiveness encoding', () {
+      final config = baseConfig(
+        backchannel: const BackchannelConfig(deciderKind: 'rule', ruleFireProbability: 0.25),
+        responsiveness: const ResponsivenessConfig(enableOnFirstReply: true),
+      );
+      final session = sessionUpdateEvent(config)['session'] as Map;
+      final pd = session['providerData'] as Map;
+
+      final bc = pd['backchannel'] as Map;
+      expect(bc['enabled'], true);
+      expect(bc['max_per_turn'], 3);
+      expect(bc['decider_kind'], 'rule');
+      expect(bc['rule_fire_probability'], 0.25);
+
+      final resp = pd['responsiveness'] as Map;
+      expect(resp['enabled'], true);
+      expect(resp['enable_filler_on_first_assistant_reply'], true);
+    });
+
+    test('rule_fire_probability omitted for llm decider', () {
+      final config = baseConfig(backchannel: const BackchannelConfig());
+      final session = sessionUpdateEvent(config)['session'] as Map;
+      final bc = (session['providerData'] as Map)['backchannel'] as Map;
+      expect(bc.containsKey('rule_fire_probability'), isFalse);
+    });
+
+    test('optional fields encode when set', () {
+      final config = baseConfig(
+        temperature: 0.9,
+        maxOutputTokens: 1024,
+        speechSpeed: 1.25,
+        transcriptionModel: 'inworld/inworld-stt-1',
+        transcriptionLanguage: 'en',
+        noiseReduction: 'near_field',
+      );
+      final session = sessionUpdateEvent(config)['session'] as Map;
+      expect(session['temperature'], 0.9);
+      expect(session['max_output_tokens'], 1024);
+
+      final input = (session['audio'] as Map)['input'] as Map;
+      final transcription = input['transcription'] as Map;
+      expect(transcription['model'], 'inworld/inworld-stt-1');
+      expect(transcription['language'], 'en');
+      expect((input['noise_reduction'] as Map)['type'], 'near_field');
+      expect(((session['audio'] as Map)['output'] as Map)['speed'], 1.25);
+    });
+  });
+
+  test('conversationItemCreateEvent shape', () {
+    final json = conversationItemCreateEvent('Say hello.');
+    expect(json['type'], 'conversation.item.create');
+    final item = json['item'] as Map;
+    expect(item['type'], 'message');
+    expect(item['role'], 'user');
+    final content = item['content'] as List;
+    expect(content.length, 1);
+    expect((content.first as Map)['type'], 'input_text');
+    expect((content.first as Map)['text'], 'Say hello.');
+  });
+
+  test('response.create and response.cancel', () {
+    expect(responseCreateEvent()['type'], 'response.create');
+    expect(responseCancelEvent()['type'], 'response.cancel');
+  });
+}

--- a/realtime/flutter/webrtc/test/conversation_controller_test.dart
+++ b/realtime/flutter/webrtc/test/conversation_controller_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:inworld_voice_agent/state/conversation_controller.dart';
+
+void main() {
+  group('reconcileTranscript', () {
+    test('empty existing returns delta', () {
+      expect(ConversationController.reconcileTranscript('', 'hello'), 'hello');
+    });
+
+    test('cumulative re-send of same text is idempotent', () {
+      expect(ConversationController.reconcileTranscript('hello', 'hello'), 'hello');
+    });
+
+    test('cumulative growth replaces', () {
+      expect(
+        ConversationController.reconcileTranscript('hello', 'hello world'),
+        'hello world',
+      );
+    });
+
+    test('stale shorter snapshot is ignored', () {
+      expect(
+        ConversationController.reconcileTranscript('hello world', 'hello'),
+        'hello world',
+      );
+    });
+
+    test('genuine incremental chunk appends', () {
+      expect(
+        ConversationController.reconcileTranscript('hello ', 'world'),
+        'hello world',
+      );
+    });
+  });
+}

--- a/realtime/flutter/webrtc/test/server_event_decoding_test.dart
+++ b/realtime/flutter/webrtc/test/server_event_decoding_test.dart
@@ -1,0 +1,102 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:inworld_voice_agent/realtime/events/server_event.dart';
+
+ServerEvent decode(Map<String, dynamic> obj) => ServerEvent.decode(jsonEncode(obj));
+
+void main() {
+  test('output text delta variants map to one case', () {
+    for (final type in [
+      'response.output_text.delta',
+      'response.text.delta',
+      'response.audio_transcript.delta',
+      'response.output_audio_transcript.delta',
+    ]) {
+      final event = decode({'type': type, 'delta': 'hi'});
+      expect(event, isA<OutputTextDelta>());
+      expect((event as OutputTextDelta).delta, 'hi');
+    }
+  });
+
+  test('transcript done from top-level and content_part', () {
+    expect(
+      (decode({'type': 'response.output_audio_transcript.done', 'transcript': 'done'})
+              as TranscriptDone)
+          .text,
+      'done',
+    );
+    expect(
+      (decode({
+        'type': 'response.content_part.done',
+        'part': {'transcript': 'part'},
+      }) as TranscriptDone)
+          .text,
+      'part',
+    );
+  });
+
+  test('input transcription delta and completed', () {
+    expect(
+      (decode({
+        'type': 'conversation.item.input_audio_transcription.delta',
+        'delta': 'ab',
+      }) as InputTranscriptionDelta)
+          .delta,
+      'ab',
+    );
+    expect(
+      (decode({
+        'type': 'conversation.item.input_audio_transcription.completed',
+        'transcript': 'final',
+      }) as InputTranscriptionCompleted)
+          .transcript,
+      'final',
+    );
+  });
+
+  test('lifecycle events', () {
+    expect(decode({'type': 'input_audio_buffer.speech_started'}), isA<SpeechStarted>());
+    expect(decode({'type': 'response.output_item.added'}), isA<OutputItemAdded>());
+    expect(decode({'type': 'response.done'}), isA<ResponseDone>());
+  });
+
+  test('backchannel events', () {
+    expect(
+      (decode({'type': 'response.backchannel.audio.delta', 'delta': 'AAA='})
+              as BackchannelAudioDelta)
+          .base64Pcm16,
+      'AAA=',
+    );
+    expect(
+      (decode({'type': 'response.backchannel.audio.done', 'phrase': 'uh-huh'})
+              as BackchannelAudioDone)
+          .phrase,
+      'uh-huh',
+    );
+    expect(
+      (decode({'type': 'response.backchannel.skipped', 'reason': 'too soon'})
+              as BackchannelSkipped)
+          .reason,
+      'too soon',
+    );
+  });
+
+  test('error from nested and flat message', () {
+    expect(
+      (decode({
+        'type': 'error',
+        'error': {'message': 'nested'},
+      }) as ErrorEvent)
+          .message,
+      'nested',
+    );
+    expect((decode({'type': 'error', 'message': 'flat'}) as ErrorEvent).message, 'flat');
+  });
+
+  test('unknown and malformed fall back to UnknownEvent', () {
+    expect((decode({'type': 'something.new'}) as UnknownEvent).type, 'something.new');
+    expect(ServerEvent.decode('not json'), isA<UnknownEvent>());
+    expect(ServerEvent.decode('{}'), isA<UnknownEvent>());
+  });
+}


### PR DESCRIPTION
## Summary

Adds a **Flutter (iOS + Android)** voice-agent example for the Inworld Realtime API over WebRTC at `realtime/flutter/webrtc`, mirroring the native [iOS](../tree/main/realtime/ios/webrtc) and [Android](../tree/main/realtime/android/webrtc) examples in a single Dart codebase.

Scoped as a **cross-platform quickstart** (per design discussion): full protocol + transcript + settings + back-channel, but *without* the native examples' audio-engineering debug section (audio-session mode / hardware-AEC toggles), which sits below Flutter and would need per-platform native channels. Those examples remain the reference for echo/AEC tuning.

### What's included
- **Realtime protocol** — `session.update` (semantic VAD, web search, back-channel, responsiveness), greeting `conversation.item.create`, `response.create`; streaming transcript for both roles; barge-in (mute agent track + `response.cancel` + drop in-flight bubble).
- **The JSON casing contract** — snake_case everywhere except the literal camelCase `providerData` key (the Go server ignores `provider_data`). Built by hand in `client_events.dart` and asserted byte-for-byte in tests.
- **WebRTC** — `flutter_webrtc` unified-plan peer connection + `oai-events` data channel + mic track; ICE gathering waiter (complete | 500 ms quiet | 3 s cap).
- **Auth** — Basic and Backend-JWT, same two variants as the other examples.
- **Back-channel** — PCM16 chunks buffered per interjection and played as a WAV clip (Flutter has no stock streaming-PCM sink; interjections are short so latency is negligible).
- **Tests** — event encoding/decoding + transcript reconciliation (pure Dart, no device).

### Simplifications vs. the native apps (documented in the example README)
- No audio-engineering debug section (see above).
- Model/voice are free-text fields rather than live catalog pickers.

### Also
- Root `README.md` + `realtime/README.md` updated to list the iOS, Android, and Flutter examples — the realtime table was stale (missing iOS/Android too).
- The Flutter example's `.gitignore` re-includes `lib/` because the repo-root (Python-oriented) `.gitignore` ignores `lib/` — the native examples use `Sources/`/`app/src/` so they never hit this.

## Test plan
> [!IMPORTANT]
> **Not built/tested locally — there is no Flutter SDK on the authoring machine**, and the repo has no Flutter CI. The code is a careful port of the two native examples (the wire contract and connect sequence are copied verbatim), but it needs a real `flutter analyze` + `flutter test` before merge. Please verify:

```sh
cd realtime/flutter/webrtc
cp lib/secrets.dart.example lib/secrets.dart
flutter create .          # scaffold android/ ios/ runners (gitignored)
# apply the mic-permission edits from the README
flutter pub get
flutter analyze
flutter test              # event encoding/decoding + transcript reconciliation
flutter run               # device/simulator smoke test with a real INWORLD_API_KEY
```

Likely follow-ups a build will surface: dependency version pins in `pubspec.yaml`, and the `DropdownButtonFormField` `initialValue` vs `value` API (targeted at Flutter 3.24+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)